### PR TITLE
Fix for issue #231

### DIFF
--- a/FetchXmlBuilder/FetchXmlBuilder.cs
+++ b/FetchXmlBuilder/FetchXmlBuilder.cs
@@ -1884,6 +1884,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder
             }
             LogUse("New");
             dockControlBuilder.Init(null, "new", false);
+            liveUpdateXml = string.Empty;
         }
 
         private void tsbOptions_Click(object sender, EventArgs e)


### PR DESCRIPTION
While debugging the issue, I was able to determine that the problem might be an edge case. If you already have FXB up and running and have a query and then click new and then paste the exact same FetchXml, then because the "liveUpdateXml" variable already has the previous xml, it causes the code at line 1841 to not cause an update of the tree.