### PR TITLE
Apply updates live

### DIFF
--- a/FetchXmlBuilder/Controls/attributeControl.cs
+++ b/FetchXmlBuilder/Controls/attributeControl.cs
@@ -43,7 +43,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             node = Node;
             PopulateControls(Node, attributes);
-            ControlUtils.FillControls(collec, this.Controls);
+            ControlUtils.FillControls(collec, this.Controls, this);
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
             Saved += tree.CtrlSaved;
         }
@@ -68,7 +68,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
         }
 
-        public void Save()
+        public void Save(bool silent)
         {
             try
             {
@@ -81,8 +81,11 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             catch (ArgumentNullException ex)
             {
-                MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
-                Focus();
+                if (!silent)
+                {
+                    MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                    Focus();
+                }
             }
         }
 
@@ -119,7 +122,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             if (controlsCheckSum != ControlUtils.ControlsChecksum(this.Controls))
             {
-                Save();
+                Save(false);
             }
         }
 

--- a/FetchXmlBuilder/Controls/commentControl.cs
+++ b/FetchXmlBuilder/Controls/commentControl.cs
@@ -35,12 +35,12 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             if (collection != null)
                 collec = collection;
 
-            ControlUtils.FillControls(collec, this.Controls);
+            ControlUtils.FillControls(collec, this.Controls, this);
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
             Saved += tree.CtrlSaved;
         }
 
-        public void Save()
+        public void Save(bool silent)
         {
             try
             {
@@ -49,7 +49,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             catch (ArgumentNullException ex)
             {
-                MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                if (!silent)
+                    MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
             }
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
         }
@@ -73,7 +74,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             if (controlsCheckSum != ControlUtils.ControlsChecksum(this.Controls))
             {
-                Save();
+                Save(false);
             }
         }
     }

--- a/FetchXmlBuilder/Controls/conditionControl.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.cs
@@ -48,7 +48,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             PopulateControls();
             RefreshAttributes();
-            ControlUtils.FillControls(collec, this.Controls);
+            ControlUtils.FillControls(collec, this.Controls, this);
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
             Saved += tree.CtrlSaved;
         }
@@ -84,13 +84,13 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             return result;
         }
 
-        public void Save()
+        public void Save(bool silent)
         {
             try
             {
                 if (ValidateForm())
                 {
-                    if (cmbOperator.SelectedItem != null && cmbOperator.SelectedItem is OperatorItem)
+                    if (!silent && cmbOperator.SelectedItem != null && cmbOperator.SelectedItem is OperatorItem)
                     {
                         var oper = (OperatorItem)cmbOperator.SelectedItem;
                         if (oper.IsMultipleValuesType && !string.IsNullOrWhiteSpace(cmbValue.Text))
@@ -115,7 +115,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             catch (ArgumentNullException ex)
             {
-                MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                if (!silent)
+                    MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
             }
         }
 
@@ -269,7 +270,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             if (controlsCheckSum != ControlUtils.ControlsChecksum(this.Controls))
             {
-                Save();
+                Save(false);
             }
         }
 
@@ -305,8 +306,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                 AttributeItem.AddAttributeToComboBox(cmbAttribute, attribute, true, FetchXmlBuilder.friendlyNames);
             }
             // RefreshFill now that attributes are loaded
-            ControlUtils.FillControl(collec, cmbAttribute);
-            ControlUtils.FillControl(collec, cmbValue);
+            ControlUtils.FillControl(collec, cmbAttribute, this);
+            ControlUtils.FillControl(collec, cmbValue, this);
         }
 
         private static TreeNode GetClosestEntityNode(TreeNode node)
@@ -398,7 +399,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                     cmbOperator.SelectedItem = null;
                     cmbOperator.Items.Clear();
                     cmbOperator.Items.AddRange(OperatorItem.GetConditionsByAttributeType(attributeType.Value));
-                    ControlUtils.FillControl(tmpColl, cmbOperator);
+                    ControlUtils.FillControl(tmpColl, cmbOperator, this);
                 }
             }
             UpdateValueField();

--- a/FetchXmlBuilder/Controls/entityControl.cs
+++ b/FetchXmlBuilder/Controls/entityControl.cs
@@ -39,7 +39,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                 collec = collection;
 
             PopulateControls();
-            ControlUtils.FillControls(collec, this.Controls);
+            ControlUtils.FillControls(collec, this.Controls, this);
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
             Saved += tree.CtrlSaved;
         }
@@ -57,7 +57,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
         }
 
-        public void Save()
+        public void Save(bool silent)
         {
             try
             {
@@ -66,7 +66,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             catch (ArgumentNullException ex)
             {
-                MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                if (!silent)
+                    MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
             }
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
         }
@@ -90,7 +91,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             if (controlsCheckSum != ControlUtils.ControlsChecksum(this.Controls))
             {
-                Save();
+                Save(false);
             }
         }
     }

--- a/FetchXmlBuilder/Controls/fetchControl.cs
+++ b/FetchXmlBuilder/Controls/fetchControl.cs
@@ -35,12 +35,12 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             if (collection != null)
                 collec = collection;
 
-            ControlUtils.FillControls(collec, this.Controls);
+            ControlUtils.FillControls(collec, this.Controls, this);
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
             Saved += tree.CtrlSaved;
         }
 
-        public void Save()
+        public void Save(bool silent)
         {
             try
             {
@@ -49,7 +49,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             catch (ArgumentNullException ex)
             {
-                MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                if (!silent)
+                    MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
             }
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
         }
@@ -73,7 +74,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             if (controlsCheckSum != ControlUtils.ControlsChecksum(this.Controls))
             {
-                Save();
+                Save(false);
             }
         }
 

--- a/FetchXmlBuilder/Controls/filterControl.cs
+++ b/FetchXmlBuilder/Controls/filterControl.cs
@@ -35,12 +35,12 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             if (collection != null)
                 collec = collection;
 
-            ControlUtils.FillControls(collec, this.Controls);
+            ControlUtils.FillControls(collec, this.Controls, this);
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
             Saved += tree.CtrlSaved;
         }
 
-        public void Save()
+        public void Save(bool silent)
         {
             try
             {
@@ -49,7 +49,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             catch (ArgumentNullException ex)
             {
-                MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                if (!silent)
+                    MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
             }
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
         }
@@ -73,7 +74,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             if (controlsCheckSum != ControlUtils.ControlsChecksum(this.Controls))
             {
-                Save();
+                Save(false);
             }
         }
     }

--- a/FetchXmlBuilder/Controls/linkEntityControl.cs
+++ b/FetchXmlBuilder/Controls/linkEntityControl.cs
@@ -45,7 +45,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                 collec = new Dictionary<string, string>();
             }
             PopulateControls();
-            ControlUtils.FillControls(collec, this.Controls);
+            ControlUtils.FillControls(collec, this.Controls, this);
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
             Saved += tree.CtrlSaved;
         }
@@ -77,7 +77,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             RefreshAttributes();
         }
 
-        public void Save()
+        public void Save(bool silent)
         {
             try
             {
@@ -86,7 +86,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             catch (ArgumentNullException ex)
             {
-                MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                if (!silent)
+                    MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
             }
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
         }
@@ -107,7 +108,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             if (controlsCheckSum != ControlUtils.ControlsChecksum(this.Controls))
             {
-                Save();
+                Save(false);
             }
         }
 

--- a/FetchXmlBuilder/Controls/orderControl.cs
+++ b/FetchXmlBuilder/Controls/orderControl.cs
@@ -45,7 +45,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
 
             PopulateControls(Node, attributes);
-            ControlUtils.FillControls(collec, this.Controls);
+            ControlUtils.FillControls(collec, this.Controls, this);
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
             Saved += tree.CtrlSaved;
         }
@@ -98,7 +98,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             return result;
         }
 
-        public void Save()
+        public void Save(bool silent)
         {
             try
             {
@@ -107,7 +107,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             catch (ArgumentNullException ex)
             {
-                MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                if (!silent)
+                    MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
             }
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
         }
@@ -131,7 +132,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             if (controlsCheckSum != ControlUtils.ControlsChecksum(this.Controls))
             {
-                Save();
+                Save(false);
             }
         }
     }

--- a/FetchXmlBuilder/Controls/valueControl.cs
+++ b/FetchXmlBuilder/Controls/valueControl.cs
@@ -35,12 +35,12 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             if (collection != null)
                 collec = collection;
 
-            ControlUtils.FillControls(collec, this.Controls);
+            ControlUtils.FillControls(collec, this.Controls, this);
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
             Saved += tree.CtrlSaved;
         }
 
-        public void Save()
+        public void Save(bool silent)
         {
             try
             {
@@ -49,7 +49,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
             catch (ArgumentNullException ex)
             {
-                MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                if (!silent)
+                    MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
             }
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
         }
@@ -73,7 +74,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             if (controlsCheckSum != ControlUtils.ControlsChecksum(this.Controls))
             {
-                Save();
+                Save(false);
             }
         }
     }

--- a/XmlEditorUtils/ControlUtils.cs
+++ b/XmlEditorUtils/ControlUtils.cs
@@ -78,15 +78,15 @@ namespace Cinteros.Xrm.XmlEditorUtils
             return collection;
         }
 
-        public static void FillControls(Dictionary<string, string> collection, System.Windows.Forms.Control.ControlCollection controls)
+        public static void FillControls(Dictionary<string, string> collection, System.Windows.Forms.Control.ControlCollection controls, IDefinitionSavable saveable)
         {
             foreach (Control control in controls.Cast<Control>().Where(y => y.Tag != null).OrderBy(y => y.TabIndex))
             {
-                FillControl(collection, control);
+                FillControl(collection, control, saveable);
             }
         }
 
-        public static void FillControl(Dictionary<string, string> collection, Control control)
+        public static void FillControl(Dictionary<string, string> collection, Control control, IDefinitionSavable saveable)
         {
             string attribute;
             bool required;
@@ -94,14 +94,16 @@ namespace Cinteros.Xrm.XmlEditorUtils
             if (ControlUtils.GetControlDefinition(control, out attribute, out required, out defaultvalue))
             {
                 var value = collection.ContainsKey(attribute) ? collection[attribute] : defaultvalue;
-                if (control is CheckBox)
+                if (control is CheckBox chkbox)
                 {
                     bool.TryParse(value, out bool chk);
-                    ((CheckBox)control).Checked = chk;
+                    chkbox.Checked = chk;
+                    chkbox.CheckedChanged += (s, e) => saveable.Save(true);
                 }
-                else if (control is TextBox)
+                else if (control is TextBox txt)
                 {
-                    ((TextBox)control).Text = value;
+                    txt.Text = value;
+                    txt.TextChanged += (s, e) => saveable.Save(true);
                 }
                 else if (control is ComboBox cmb)
                 {
@@ -129,6 +131,8 @@ namespace Cinteros.Xrm.XmlEditorUtils
                     {
                         cmb.Text = value;
                     }
+
+                    cmb.TextChanged += (s, e) => saveable.Save(true);
                 }
             }
         }

--- a/XmlEditorUtils/IDefinitionSavable.cs
+++ b/XmlEditorUtils/IDefinitionSavable.cs
@@ -6,6 +6,6 @@ namespace Cinteros.Xrm.XmlEditorUtils
 {
     public interface IDefinitionSavable
     {
-        void Save();
+        void Save(bool silent);
     }
 }


### PR DESCRIPTION
Not sure if this is just me, but I can find it confusing when I change a setting on a query (e.g. select an attribute in the drop-down list on a condition node) and it's not reflected elsewhere in the UI until the focus leaves the whole editor area.

This PR triggers the `Save` method on each editor control whenever any input changes, so all changes are reflected live throughout the UI. Any errors generated during the save process are suppressed so you don't get a load of popup messages while editing though.