### PR TITLE
SQL 4 CDS Integration

### DIFF
--- a/FetchXmlBuilder/AppCode/FXBSettings.cs
+++ b/FetchXmlBuilder/AppCode/FXBSettings.cs
@@ -23,6 +23,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
         public DockStates DockStates { get; set; } = new DockStates();
         public ContentWindows ContentWindows { get; set; } = new ContentWindows();
         public bool OpenUncustomizableViews { get; set; } = false;
+        public bool UseSQL4CDS { get; set; }
     }
 
     public class QueryOptions

--- a/FetchXmlBuilder/DockControls/XmlContentControl.cs
+++ b/FetchXmlBuilder/DockControls/XmlContentControl.cs
@@ -62,6 +62,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.DockControls
             panExecute.Visible = allowedit;
             panParseQE.Visible = allowparse;
             panSQL4CDS.Visible = allowsql;
+            panSQL4CDSInfo.Visible = allowsql;
         }
 
         internal void SetFormat(SaveFormat saveFormat)
@@ -106,6 +107,12 @@ namespace Cinteros.Xrm.FetchXmlBuilder.DockControls
             txtXML.Text = xmlString;
             txtXML.Settings.QuoteCharacter = fxb.settings.QueryOptions.UseSingleQuotation ? '\'' : '"';
             FormatXML(true);
+        }
+
+        public void UpdateSQL(string sql, bool sql4cds)
+        {
+            txtXML.Text = sql;
+            panSQL4CDSInfo.Visible = !sql4cds;
         }
 
         private void btnCancel_Click(object sender, EventArgs e)

--- a/FetchXmlBuilder/DockControls/XmlContentControl.cs
+++ b/FetchXmlBuilder/DockControls/XmlContentControl.cs
@@ -52,6 +52,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.DockControls
             var windowSettings = fxb.settings.ContentWindows.GetContentWindow(contenttype);
             var allowedit = contenttype == ContentType.FetchXML;
             var allowparse = contenttype == ContentType.QueryExpression;
+            var allowsql = contenttype == ContentType.SQL_Query;
             chkLiveUpdate.Checked = allowedit && windowSettings.LiveUpdate;
             lblFormatExpander.GroupBoxSetState(tt, windowSettings.FormatExpanded);
             lblActionsExpander.GroupBoxSetState(tt, windowSettings.ActionExpanded);
@@ -60,6 +61,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.DockControls
             panFormatting.Visible = allowedit;
             panExecute.Visible = allowedit;
             panParseQE.Visible = allowparse;
+            panSQL4CDS.Visible = allowsql;
         }
 
         internal void SetFormat(SaveFormat saveFormat)
@@ -398,6 +400,11 @@ namespace Cinteros.Xrm.FetchXmlBuilder.DockControls
                 ActionExpanded = gbActions.IsExpanded()
             };
             fxb.settings.ContentWindows.SetContentWindow(contenttype, windowSettings);
+        }
+
+        private void btnSQL4CDS_Click(object sender, EventArgs e)
+        {
+            fxb.EditInSQL4CDS();
         }
     }
 

--- a/FetchXmlBuilder/DockControls/XmlContentControl.designer.cs
+++ b/FetchXmlBuilder/DockControls/XmlContentControl.designer.cs
@@ -40,6 +40,8 @@
             this.txtXML = new CSRichTextBoxSyntaxHighlighting.XMLViewer();
             this.panActions = new System.Windows.Forms.Panel();
             this.gbActions = new System.Windows.Forms.GroupBox();
+            this.panSQL4CDS = new System.Windows.Forms.Panel();
+            this.btnSQL4CDS = new System.Windows.Forms.Button();
             this.lblActionsExpander = new System.Windows.Forms.Label();
             this.panExecute = new System.Windows.Forms.Panel();
             this.panParseQE = new System.Windows.Forms.Panel();
@@ -56,11 +58,12 @@
             this.rbFormatXML = new System.Windows.Forms.RadioButton();
             this.btnFormat = new System.Windows.Forms.Button();
             this.tt = new System.Windows.Forms.ToolTip(this.components);
-            this.panSQL4CDS = new System.Windows.Forms.Panel();
-            this.btnSQL4CDS = new System.Windows.Forms.Button();
+            this.panSQL4CDSInfo = new System.Windows.Forms.Panel();
+            this.lblSQL4CDSInfo = new System.Windows.Forms.Label();
             this.panCancel.SuspendLayout();
             this.panActions.SuspendLayout();
             this.gbActions.SuspendLayout();
+            this.panSQL4CDS.SuspendLayout();
             this.panExecute.SuspendLayout();
             this.panParseQE.SuspendLayout();
             this.panSave.SuspendLayout();
@@ -68,7 +71,7 @@
             this.panLiveUpdate.SuspendLayout();
             this.panFormatting.SuspendLayout();
             this.gbFormatting.SuspendLayout();
-            this.panSQL4CDS.SuspendLayout();
+            this.panSQL4CDSInfo.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnSave
@@ -188,6 +191,27 @@
             this.gbActions.TabIndex = 4;
             this.gbActions.TabStop = false;
             this.gbActions.Text = "Actions";
+            // 
+            // panSQL4CDS
+            // 
+            this.panSQL4CDS.Controls.Add(this.btnSQL4CDS);
+            this.panSQL4CDS.Dock = System.Windows.Forms.DockStyle.Right;
+            this.panSQL4CDS.Location = new System.Drawing.Point(85, 16);
+            this.panSQL4CDS.Name = "panSQL4CDS";
+            this.panSQL4CDS.Size = new System.Drawing.Size(118, 28);
+            this.panSQL4CDS.TabIndex = 8;
+            this.panSQL4CDS.Visible = false;
+            // 
+            // btnSQL4CDS
+            // 
+            this.btnSQL4CDS.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnSQL4CDS.Location = new System.Drawing.Point(6, 0);
+            this.btnSQL4CDS.Name = "btnSQL4CDS";
+            this.btnSQL4CDS.Size = new System.Drawing.Size(106, 23);
+            this.btnSQL4CDS.TabIndex = 4;
+            this.btnSQL4CDS.Text = "Edit in SQL 4 CDS";
+            this.btnSQL4CDS.UseVisualStyleBackColor = true;
+            this.btnSQL4CDS.Click += new System.EventHandler(this.btnSQL4CDS_Click);
             // 
             // lblActionsExpander
             // 
@@ -356,26 +380,28 @@
             this.btnFormat.UseVisualStyleBackColor = true;
             this.btnFormat.Click += new System.EventHandler(this.btnFormat_Click);
             // 
-            // panSQL4CDS
+            // panSQL4CDSInfo
             // 
-            this.panSQL4CDS.Controls.Add(this.btnSQL4CDS);
-            this.panSQL4CDS.Dock = System.Windows.Forms.DockStyle.Right;
-            this.panSQL4CDS.Location = new System.Drawing.Point(85, 16);
-            this.panSQL4CDS.Name = "panSQL4CDS";
-            this.panSQL4CDS.Size = new System.Drawing.Size(118, 28);
-            this.panSQL4CDS.TabIndex = 8;
-            this.panSQL4CDS.Visible = false;
+            this.panSQL4CDSInfo.BackColor = System.Drawing.SystemColors.Info;
+            this.panSQL4CDSInfo.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panSQL4CDSInfo.Controls.Add(this.lblSQL4CDSInfo);
+            this.panSQL4CDSInfo.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.panSQL4CDSInfo.Location = new System.Drawing.Point(0, 223);
+            this.panSQL4CDSInfo.Name = "panSQL4CDSInfo";
+            this.panSQL4CDSInfo.Padding = new System.Windows.Forms.Padding(4);
+            this.panSQL4CDSInfo.Size = new System.Drawing.Size(682, 42);
+            this.panSQL4CDSInfo.TabIndex = 11;
             // 
-            // btnSQL4CDS
+            // lblSQL4CDSInfo
             // 
-            this.btnSQL4CDS.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnSQL4CDS.Location = new System.Drawing.Point(6, 0);
-            this.btnSQL4CDS.Name = "btnSQL4CDS";
-            this.btnSQL4CDS.Size = new System.Drawing.Size(106, 23);
-            this.btnSQL4CDS.TabIndex = 4;
-            this.btnSQL4CDS.Text = "Edit in SQL 4 CDS";
-            this.btnSQL4CDS.UseVisualStyleBackColor = true;
-            this.btnSQL4CDS.Click += new System.EventHandler(this.btnSQL4CDS_Click);
+            this.lblSQL4CDSInfo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblSQL4CDSInfo.Location = new System.Drawing.Point(4, 4);
+            this.lblSQL4CDSInfo.Name = "lblSQL4CDSInfo";
+            this.lblSQL4CDSInfo.Size = new System.Drawing.Size(672, 32);
+            this.lblSQL4CDSInfo.TabIndex = 0;
+            this.lblSQL4CDSInfo.Text = "FetchXML to SQL conversion works better when the SQL 4 CDS tool is also installed" +
+    ". Get it from the toolbox and enable SQL 4 CDS in the FetchXML Builder settings " +
+    "to get the improved experience.";
             // 
             // XmlContentControl
             // 
@@ -385,6 +411,7 @@
             this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(682, 359);
             this.Controls.Add(this.txtXML);
+            this.Controls.Add(this.panSQL4CDSInfo);
             this.Controls.Add(this.panFormatting);
             this.Controls.Add(this.panActions);
             this.DockAreas = ((WeifenLuo.WinFormsUI.Docking.DockAreas)((((WeifenLuo.WinFormsUI.Docking.DockAreas.Float | WeifenLuo.WinFormsUI.Docking.DockAreas.DockLeft) 
@@ -402,6 +429,7 @@
             this.panActions.ResumeLayout(false);
             this.gbActions.ResumeLayout(false);
             this.gbActions.PerformLayout();
+            this.panSQL4CDS.ResumeLayout(false);
             this.panExecute.ResumeLayout(false);
             this.panParseQE.ResumeLayout(false);
             this.panSave.ResumeLayout(false);
@@ -411,7 +439,7 @@
             this.panFormatting.ResumeLayout(false);
             this.gbFormatting.ResumeLayout(false);
             this.gbFormatting.PerformLayout();
-            this.panSQL4CDS.ResumeLayout(false);
+            this.panSQL4CDSInfo.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -444,5 +472,7 @@
         private System.Windows.Forms.ToolTip tt;
         private System.Windows.Forms.Panel panSQL4CDS;
         private System.Windows.Forms.Button btnSQL4CDS;
+        private System.Windows.Forms.Panel panSQL4CDSInfo;
+        private System.Windows.Forms.Label lblSQL4CDSInfo;
     }
 }

--- a/FetchXmlBuilder/DockControls/XmlContentControl.designer.cs
+++ b/FetchXmlBuilder/DockControls/XmlContentControl.designer.cs
@@ -56,6 +56,8 @@
             this.rbFormatXML = new System.Windows.Forms.RadioButton();
             this.btnFormat = new System.Windows.Forms.Button();
             this.tt = new System.Windows.Forms.ToolTip(this.components);
+            this.panSQL4CDS = new System.Windows.Forms.Panel();
+            this.btnSQL4CDS = new System.Windows.Forms.Button();
             this.panCancel.SuspendLayout();
             this.panActions.SuspendLayout();
             this.gbActions.SuspendLayout();
@@ -66,6 +68,7 @@
             this.panLiveUpdate.SuspendLayout();
             this.panFormatting.SuspendLayout();
             this.gbFormatting.SuspendLayout();
+            this.panSQL4CDS.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnSave
@@ -171,6 +174,7 @@
             // 
             this.gbActions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.gbActions.Controls.Add(this.panSQL4CDS);
             this.gbActions.Controls.Add(this.lblActionsExpander);
             this.gbActions.Controls.Add(this.panExecute);
             this.gbActions.Controls.Add(this.panParseQE);
@@ -352,6 +356,27 @@
             this.btnFormat.UseVisualStyleBackColor = true;
             this.btnFormat.Click += new System.EventHandler(this.btnFormat_Click);
             // 
+            // panSQL4CDS
+            // 
+            this.panSQL4CDS.Controls.Add(this.btnSQL4CDS);
+            this.panSQL4CDS.Dock = System.Windows.Forms.DockStyle.Right;
+            this.panSQL4CDS.Location = new System.Drawing.Point(85, 16);
+            this.panSQL4CDS.Name = "panSQL4CDS";
+            this.panSQL4CDS.Size = new System.Drawing.Size(118, 28);
+            this.panSQL4CDS.TabIndex = 8;
+            this.panSQL4CDS.Visible = false;
+            // 
+            // btnSQL4CDS
+            // 
+            this.btnSQL4CDS.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnSQL4CDS.Location = new System.Drawing.Point(6, 0);
+            this.btnSQL4CDS.Name = "btnSQL4CDS";
+            this.btnSQL4CDS.Size = new System.Drawing.Size(106, 23);
+            this.btnSQL4CDS.TabIndex = 4;
+            this.btnSQL4CDS.Text = "Edit in SQL 4 CDS";
+            this.btnSQL4CDS.UseVisualStyleBackColor = true;
+            this.btnSQL4CDS.Click += new System.EventHandler(this.btnSQL4CDS_Click);
+            // 
             // XmlContentControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -386,6 +411,7 @@
             this.panFormatting.ResumeLayout(false);
             this.gbFormatting.ResumeLayout(false);
             this.gbFormatting.PerformLayout();
+            this.panSQL4CDS.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -416,5 +442,7 @@
         private System.Windows.Forms.Label lblFormatExpander;
         private System.Windows.Forms.Label lblActionsExpander;
         private System.Windows.Forms.ToolTip tt;
+        private System.Windows.Forms.Panel panSQL4CDS;
+        private System.Windows.Forms.Button btnSQL4CDS;
     }
 }

--- a/FetchXmlBuilder/FetchXmlBuilder.cs
+++ b/FetchXmlBuilder/FetchXmlBuilder.cs
@@ -795,7 +795,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder
             }
             if (dockControlSQL?.Visible == true && entities != null)
             {
-                dockControlSQL.UpdateXML(GetSQLQuery());
+                var sql = GetSQLQuery(out var sql4cds);
+                dockControlSQL.UpdateSQL(sql, sql4cds);
             }
             if (dockControlFetchXmlCs?.Visible == true)
             {
@@ -1029,18 +1030,26 @@ namespace Cinteros.Xrm.FetchXmlBuilder
             return code;
         }
 
-        private string GetSQLQuery()
+        private string GetSQLQuery(out bool sql4cds)
         {
-            var param = new Dictionary<string,object>
+            sql4cds = false;
+
+            if (settings.UseSQL4CDS)
             {
-                ["FetchXml"] = dockControlBuilder.GetFetchString(false, false),
-                ["ConvertOnly"] = true
-            };
+                var param = new Dictionary<string, object>
+                {
+                    ["FetchXml"] = dockControlBuilder.GetFetchString(false, false),
+                    ["ConvertOnly"] = true
+                };
 
-            OnOutgoingMessage(this, new MessageBusEventArgs("SQL 4 CDS") { TargetArgument = param });
+                OnOutgoingMessage(this, new MessageBusEventArgs("SQL 4 CDS") { TargetArgument = param });
 
-            if (param.TryGetValue("Sql", out var s))
-                return (string) s;
+                if (param.TryGetValue("Sql", out var s))
+                {
+                    sql4cds = true;
+                    return (string)s;
+                }
+            }
 
             var sql = string.Empty;
             var fetch = dockControlBuilder.GetFetchType();

--- a/FetchXmlBuilder/FetchXmlBuilder.cs
+++ b/FetchXmlBuilder/FetchXmlBuilder.cs
@@ -259,6 +259,9 @@ namespace Cinteros.Xrm.FetchXmlBuilder
 
         public void OnIncomingMessage(MessageBusEventArgs message)
         {
+            if (message.TargetArgument == null)
+                return;
+
             callerArgs = message;
             var fetchXml = string.Empty;
             var requestedType = "FetchXML";
@@ -1028,6 +1031,17 @@ namespace Cinteros.Xrm.FetchXmlBuilder
 
         private string GetSQLQuery()
         {
+            var param = new Dictionary<string,object>
+            {
+                ["FetchXml"] = dockControlBuilder.GetFetchString(false, false),
+                ["ConvertOnly"] = true
+            };
+
+            OnOutgoingMessage(this, new MessageBusEventArgs("SQL 4 CDS") { TargetArgument = param });
+
+            if (param.TryGetValue("Sql", out var s))
+                return (string) s;
+
             var sql = string.Empty;
             var fetch = dockControlBuilder.GetFetchType();
             try

--- a/FetchXmlBuilder/FetchXmlBuilder.cs
+++ b/FetchXmlBuilder/FetchXmlBuilder.cs
@@ -1055,6 +1055,11 @@ namespace Cinteros.Xrm.FetchXmlBuilder
             return sql;
         }
 
+        public void EditInSQL4CDS()
+        {
+            OnOutgoingMessage(this, new MessageBusEventArgs("SQL 4 CDS") { TargetArgument = dockControlBuilder.GetFetchString(false, false) });
+        }
+
         private string GetCSharpCode()
         {
             var cs = string.Empty;

--- a/FetchXmlBuilder/Forms/Settings.Designer.cs
+++ b/FetchXmlBuilder/Forms/Settings.Designer.cs
@@ -71,6 +71,7 @@
             this.panel2 = new System.Windows.Forms.Panel();
             this.btnDefaultQuery = new System.Windows.Forms.Button();
             this.btnFormatQuery = new System.Windows.Forms.Button();
+            this.chkUseSQL4CDS = new System.Windows.Forms.CheckBox();
             this.gbEntities.SuspendLayout();
             this.gbAttributes.SuspendLayout();
             this.gbResult.SuspendLayout();
@@ -93,7 +94,7 @@
             this.gbEntities.Controls.Add(this.chkEntAll);
             this.gbEntities.Location = new System.Drawing.Point(240, 12);
             this.gbEntities.Name = "gbEntities";
-            this.gbEntities.Size = new System.Drawing.Size(168, 226);
+            this.gbEntities.Size = new System.Drawing.Size(168, 255);
             this.gbEntities.TabIndex = 2;
             this.gbEntities.TabStop = false;
             this.gbEntities.Text = "Show Entities";
@@ -232,7 +233,7 @@
             this.gbAttributes.Controls.Add(this.chkAttAll);
             this.gbAttributes.Location = new System.Drawing.Point(414, 12);
             this.gbAttributes.Name = "gbAttributes";
-            this.gbAttributes.Size = new System.Drawing.Size(168, 226);
+            this.gbAttributes.Size = new System.Drawing.Size(168, 255);
             this.gbAttributes.TabIndex = 3;
             this.gbAttributes.TabStop = false;
             this.gbAttributes.Text = "Show Attributes";
@@ -363,7 +364,7 @@
             this.gbResult.Controls.Add(this.rbResRaw);
             this.gbResult.Controls.Add(this.rbResSerialized);
             this.gbResult.Controls.Add(this.rbResGrid);
-            this.gbResult.Location = new System.Drawing.Point(12, 135);
+            this.gbResult.Location = new System.Drawing.Point(12, 164);
             this.gbResult.Name = "gbResult";
             this.gbResult.Size = new System.Drawing.Size(222, 103);
             this.gbResult.TabIndex = 1;
@@ -430,6 +431,7 @@
             // 
             // gbAppearance
             // 
+            this.gbAppearance.Controls.Add(this.chkUseSQL4CDS);
             this.gbAppearance.Controls.Add(this.chkAppAllowUncustViews);
             this.gbAppearance.Controls.Add(this.chkAppResultsNewWindow);
             this.gbAppearance.Controls.Add(this.chkAppNoSavePrompt);
@@ -437,7 +439,7 @@
             this.gbAppearance.Controls.Add(this.chkAppFriendly);
             this.gbAppearance.Location = new System.Drawing.Point(12, 12);
             this.gbAppearance.Name = "gbAppearance";
-            this.gbAppearance.Size = new System.Drawing.Size(222, 121);
+            this.gbAppearance.Size = new System.Drawing.Size(222, 146);
             this.gbAppearance.TabIndex = 0;
             this.gbAppearance.TabStop = false;
             this.gbAppearance.Text = "Appearance";
@@ -499,7 +501,7 @@
             this.panel1.Controls.Add(this.llShowWelcome);
             this.panel1.Controls.Add(this.btnCancel);
             this.panel1.Controls.Add(this.btnOK);
-            this.panel1.Location = new System.Drawing.Point(12, 393);
+            this.panel1.Location = new System.Drawing.Point(12, 415);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(567, 53);
             this.panel1.TabIndex = 5;
@@ -542,7 +544,7 @@
             // 
             this.gbDefaultQuery.Controls.Add(this.txtFetch);
             this.gbDefaultQuery.Controls.Add(this.panel2);
-            this.gbDefaultQuery.Location = new System.Drawing.Point(12, 244);
+            this.gbDefaultQuery.Location = new System.Drawing.Point(11, 273);
             this.gbDefaultQuery.Name = "gbDefaultQuery";
             this.gbDefaultQuery.Size = new System.Drawing.Size(570, 145);
             this.gbDefaultQuery.TabIndex = 6;
@@ -558,6 +560,8 @@
             xmlViewerSettings1.AttributeValue = System.Drawing.Color.Blue;
             xmlViewerSettings1.Comment = System.Drawing.Color.Empty;
             xmlViewerSettings1.Element = System.Drawing.Color.DarkRed;
+            xmlViewerSettings1.FontName = "Consolas";
+            xmlViewerSettings1.FontSize = 9F;
             xmlViewerSettings1.QuoteCharacter = '\"';
             xmlViewerSettings1.Tag = System.Drawing.Color.Blue;
             xmlViewerSettings1.Value = System.Drawing.Color.Black;
@@ -597,13 +601,23 @@
             this.btnFormatQuery.UseVisualStyleBackColor = true;
             this.btnFormatQuery.Click += new System.EventHandler(this.btnFormatQuery_Click);
             // 
+            // chkUseSQL4CDS
+            // 
+            this.chkUseSQL4CDS.AutoSize = true;
+            this.chkUseSQL4CDS.Location = new System.Drawing.Point(16, 120);
+            this.chkUseSQL4CDS.Name = "chkUseSQL4CDS";
+            this.chkUseSQL4CDS.Size = new System.Drawing.Size(197, 17);
+            this.chkUseSQL4CDS.TabIndex = 7;
+            this.chkUseSQL4CDS.Text = "Use SQL 4 CDS for SQL conversion";
+            this.chkUseSQL4CDS.UseVisualStyleBackColor = true;
+            // 
             // Settings
             // 
             this.AcceptButton = this.btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(593, 456);
+            this.ClientSize = new System.Drawing.Size(593, 478);
             this.Controls.Add(this.gbDefaultQuery);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.gbAppearance);
@@ -673,5 +687,6 @@
         private System.Windows.Forms.Panel panel2;
         private System.Windows.Forms.Button btnFormatQuery;
         private System.Windows.Forms.Button btnDefaultQuery;
+        private System.Windows.Forms.CheckBox chkUseSQL4CDS;
     }
 }

--- a/FetchXmlBuilder/Forms/Settings.cs
+++ b/FetchXmlBuilder/Forms/Settings.cs
@@ -26,6 +26,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             chkAppNoSavePrompt.Checked = settings.DoNotPromptToSave;
             chkAppResultsNewWindow.Checked = settings.Results.AlwaysNewWindow;
             chkAppAllowUncustViews.Checked = settings.OpenUncustomizableViews;
+            chkUseSQL4CDS.Checked = settings.UseSQL4CDS;
             switch (settings.Results.ResultOption)
             {
                 case 1: rbResSerialized.Checked = true; break;
@@ -74,6 +75,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             settings.Results.SerializeStyle = cmbSeralizationStyle.SelectedIndex;
             settings.Results.RetrieveAllPages = chkResAllPages.Checked;
             settings.OpenUncustomizableViews = chkAppAllowUncustViews.Checked;
+            settings.UseSQL4CDS = chkUseSQL4CDS.Checked;
             settings.Entity.All = chkEntAll.Checked;
             settings.Entity.Customizable = chkEntCustomizable.Checked;
             settings.Entity.Uncustomizable = chkEntUncustomizable.Checked;


### PR DESCRIPTION
Integrates with SQL 4 CDS for FetchXML -> SQL conversion (requires SQL 4 CDS 1.0.3)

1. New setting to enable use of SQL 4 CDS to generate SQL pane content (disabled by default to avoid ugly messagebox popup when SQL 4 CDS is not installed)
2. Info message at the bottom of the SQL pane when the new setting is disabled
3. New "Edit in SQL 4 CDS" button at the bottom of the SQL pane to send the current FetchXML to SQL 4 CDS
4. Handle null message being sent to allow SQL 4 CDS to transfer control back to FetchXML Builder automatically without altering anything