### PR TITLE
Do not show error messages during live updates

### DIFF
--- a/FetchXmlBuilder/Controls/attributeControl.cs
+++ b/FetchXmlBuilder/Controls/attributeControl.cs
@@ -72,7 +72,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             try
             {
-                if (ValidateForm())
+                if (ValidateForm(silent))
                 {
                     Dictionary<string, string> collection = ControlUtils.GetAttributesCollection(this.Controls, true);
                     SendSaveMessage(collection);
@@ -89,13 +89,14 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
         }
 
-        private bool ValidateForm()
+        private bool ValidateForm(bool silent)
         {
             if (TreeBuilderControl.IsFetchAggregate(node))
             {
                 if (string.IsNullOrWhiteSpace(txtAlias.Text))
                 {
-                    MessageBox.Show("Alias must be specified in aggregate queries", "Condition error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    if (!silent)
+                        MessageBox.Show("Alias must be specified in aggregate queries", "Condition error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     //txtAlias.Focus();
                     return false;
                 }

--- a/FetchXmlBuilder/Controls/conditionControl.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.cs
@@ -88,7 +88,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         {
             try
             {
-                if (ValidateForm())
+                if (ValidateForm(silent))
                 {
                     if (!silent && cmbOperator.SelectedItem != null && cmbOperator.SelectedItem is OperatorItem)
                     {
@@ -120,7 +120,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             }
         }
 
-        private bool ValidateForm()
+        private bool ValidateForm(bool silent)
         {
             var result = true;
             if (cmbOperator.SelectedItem != null && cmbOperator.SelectedItem is OperatorItem)
@@ -244,7 +244,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                 }
                 if (!string.IsNullOrWhiteSpace(error))
                 {
-                    MessageBox.Show(error, "Condition error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    if (!silent)
+                        MessageBox.Show(error, "Condition error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     result = false;
                 }
             }


### PR DESCRIPTION
Addition to #262 to prevent error messages showing while still editing attribute or condition elements.