### PR TITLE
Refresh validation status after updating attribute lists

### DIFF
--- a/FetchXmlBuilder/Controls/FetchXmlElementControlBase.cs
+++ b/FetchXmlBuilder/Controls/FetchXmlElementControlBase.cs
@@ -57,6 +57,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             controlsCheckSum = ControlUtils.ControlsChecksum(this.Controls);
             Saved += tree.CtrlSaved;
             AttachValidatingEvent(this);
+            ValidateControls(true);
         }
 
         protected FetchXmlBuilder fxb { get; set; }

--- a/FetchXmlBuilder/Controls/conditionControl.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.cs
@@ -123,6 +123,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             // RefreshFill now that attributes are loaded
             FillControl(cmbAttribute);
             FillControl(cmbValue);
+            ValidateControls(true);
         }
 
         private static TreeNode GetClosestEntityNode(TreeNode node)

--- a/FetchXmlBuilder/Controls/linkEntityControl.cs
+++ b/FetchXmlBuilder/Controls/linkEntityControl.cs
@@ -149,6 +149,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                     cmbTo.Items.Add(attribute.LogicalName);
                 }
             }
+            ValidateControls(true);
         }
 
         private void cmbRelationship_SelectedIndexChanged(object sender, EventArgs e)
@@ -222,6 +223,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                     }
                 }
             }
+            ValidateControls(true);
         }
 
         private void cmbRelationship_DropDown(object sender, EventArgs e)


### PR DESCRIPTION
Currently validation doesn't happen after the list of available attributes changes, so the presence or absence of the previous validation icon can be misleading.