### PR TITLE
Batch updates to undo history

### DIFF
--- a/FetchXmlBuilder/Controls/FetchXmlElementControlBase.cs
+++ b/FetchXmlBuilder/Controls/FetchXmlElementControlBase.cs
@@ -20,8 +20,6 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         private bool validationSuspended = false;
         private int initCount;
 
-        internal bool Initializing = false;
-
         static FetchXmlElementControlBase()
         {
             // Create the small warning icon to use for user feedback

--- a/FetchXmlBuilder/Controls/FetchXmlElementControlBase.cs
+++ b/FetchXmlBuilder/Controls/FetchXmlElementControlBase.cs
@@ -9,7 +9,7 @@ using System.Windows.Forms;
 
 namespace Cinteros.Xrm.FetchXmlBuilder.Controls
 {
-    public class FetchXmlElementControlBase : UserControl, IDefinitionSavable
+    public class FetchXmlElementControlBase : UserControl, IDefinitionSavable, ISupportInitializeNotification
     {
         private Dictionary<string, string> collec;
         private Dictionary<string, string> original;
@@ -18,6 +18,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         private ErrorProvider warningProvider;
         private ErrorProvider infoProvider;
         private bool validationSuspended = false;
+        private int initCount;
 
         static FetchXmlElementControlBase()
         {
@@ -45,6 +46,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
 
         public void InitializeFXB(Dictionary<string, string> collection, FetchXmlBuilder fetchXmlBuilder, TreeBuilderControl tree, TreeNode node)
         {
+            BeginInit();
+
             fxb = fetchXmlBuilder;
             Node = node;
             Tree = tree;
@@ -78,6 +81,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             Saved += tree.CtrlSaved;
             AttachValidatingEvent(this);
             ValidateControlRecursive(this);
+
+            EndInit();
         }
 
         protected FetchXmlBuilder fxb { get; set; }
@@ -117,7 +122,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             return !controlsCheckSum.Equals(ControlUtils.ControlsChecksum(this.Controls));
         }
 
-        public virtual bool Save(bool silent)
+        public virtual bool Save(bool keyPress)
         {
             try
             {
@@ -126,11 +131,11 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                     return false;
                 }
 
-                SaveInternal(silent);
+                SaveInternal(keyPress);
             }
             catch (ArgumentNullException ex)
             {
-                if (!silent)
+                if (!keyPress)
                 {
                     MessageBox.Show(ex.Message, "Validation", MessageBoxButtons.OK, MessageBoxIcon.Stop);
                 }
@@ -142,9 +147,12 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             return true;
         }
 
-        protected virtual void SaveInternal(bool silent)
+        protected virtual void SaveInternal(bool keyPress)
         {
-            SendSaveMessage(ControlUtils.GetAttributesCollection(this.Controls, true));
+            if (IsInitialized)
+            {
+                SendSaveMessage(ControlUtils.GetAttributesCollection(this.Controls, true), keyPress);
+            }
         }
 
         protected virtual ControlValidationResult ValidateControl(Control control)
@@ -195,16 +203,20 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         /// </summary>
         /// <param name="service">IOrganizationService generated</param>
         /// <param name="parameters">Lsit of parameter</param>
-        private void SendSaveMessage(Dictionary<string, string> collection)
+        private void SendSaveMessage(Dictionary<string, string> collection, bool keyPress)
         {
-            Saved?.Invoke(this, new SaveEventArgs { AttributeCollection = collection });
+            Saved?.Invoke(this, new SaveEventArgs { AttributeCollection = collection, KeyPress = keyPress });
         }
 
         public event EventHandler<SaveEventArgs> Saved;
 
         protected void ReFillControl(Control control)
         {
+            BeginInit();
+
             ControlUtils.FillControl(collec, control, null);
+
+            EndInit();
         }
 
         protected override bool ProcessKeyPreview(ref Message m)
@@ -217,12 +229,29 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                 collec = new Dictionary<string, string>(original);
                 ControlUtils.FillControls(collec, Controls, this);
                 controlsCheckSum = ControlUtils.ControlsChecksum(Controls);
-                SendSaveMessage(original);
+                SendSaveMessage(original, false);
                 return true;
             }
 
             return base.ProcessKeyPreview(ref m);
         }
+
+        public void BeginInit()
+        {
+            initCount++;
+        }
+
+        public void EndInit()
+        {
+            initCount--;
+
+            if (initCount == 0)
+                Initialized?.Invoke(this, EventArgs.Empty);
+        }
+
+        public event EventHandler Initialized;
+
+        public bool IsInitialized => initCount == 0;
     }
 
     public enum ControlValidationLevel

--- a/FetchXmlBuilder/Controls/conditionControl.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.cs
@@ -25,12 +25,13 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         public conditionControl(TreeNode node, FetchXmlBuilder fetchXmlBuilder, TreeBuilderControl tree)
         {
             InitializeComponent();
+            BeginInit();
             txtLookup.OrganizationService = fetchXmlBuilder.Service;
             dlgLookup.Service = fetchXmlBuilder.Service;
-            Initializing = true;
             rbUseLookup.Checked = fetchXmlBuilder.settings.UseLookup;
             rbEnterGuid.Checked = !rbUseLookup.Checked;
             InitializeFXB(null, fetchXmlBuilder, tree, node);
+            EndInit();
             RefreshAttributes();
         }
 
@@ -266,7 +267,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
 
         private void RefreshAttributes()
         {
-            if (Initializing)
+            if (!IsInitialized)
             {
                 return;
             }
@@ -289,20 +290,20 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                 }
                 return;
             }
-            Initializing = true;
+            BeginInit();
             var attributes = fxb.GetDisplayAttributes(entityName);
             attributes.ToList().ForEach(a => AttributeItem.AddAttributeToComboBox(cmbAttribute, a, true, FetchXmlBuilder.friendlyNames));
             // RefreshFill now that attributes are loaded
             ReFillControl(cmbAttribute);
             ReFillControl(cmbValue);
-            Initializing = false;
+            EndInit();
             RefreshOperators();
             UpdateValueField();
         }
 
         private void RefreshOperators()
         {
-            if (Initializing)
+            if (!IsInitialized)
             {
                 return;
             }
@@ -317,7 +318,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
 
         private void UpdateValueField()
         {
-            if (Initializing)
+            if (!IsInitialized)
             {
                 return;
             }

--- a/FetchXmlBuilder/Controls/linkEntityControl.cs
+++ b/FetchXmlBuilder/Controls/linkEntityControl.cs
@@ -259,10 +259,13 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                     return;
                 }
 
+                BeginInit();
                 cmbEntity.Text = entity;
                 cmbFrom.Text = from;
                 cmbTo.Text = to;
                 chkIntersect.Checked = intersect;
+                EndInit();
+                Save(false);
             }
         }
 

--- a/FetchXmlBuilder/DockControls/TreeBuilderControl.cs
+++ b/FetchXmlBuilder/DockControls/TreeBuilderControl.cs
@@ -117,16 +117,21 @@ namespace Cinteros.Xrm.FetchXmlBuilder.DockControls
             tvFetch.SelectedNode.Tag = e.AttributeCollection;
             TreeNodeHelper.SetNodeText(tvFetch.SelectedNode, fxb);
             FetchChanged = treeChecksum != GetTreeChecksum(null);
-            var origin = "";
-            if (sender is IDefinitionSavable)
+
+            if (!e.KeyPress)
             {
-                origin = sender.ToString().Replace("Cinteros.Xrm.FetchXmlBuilder.Controls.", "").Replace("Control", "");
-                foreach (var attr in e.AttributeCollection)
+                var origin = "";
+                if (sender is IDefinitionSavable)
                 {
-                    origin += "\n  " + attr.Key + "=" + attr.Value;
+                    origin = sender.ToString().Replace("Cinteros.Xrm.FetchXmlBuilder.Controls.", "").Replace("Control", "");
+                    foreach (var attr in e.AttributeCollection)
+                    {
+                        origin += "\n  " + attr.Key + "=" + attr.Value;
+                    }
                 }
+                RecordHistory(origin);
             }
-            RecordHistory(origin);
+
             fxb.UpdateLiveXML();
         }
 

--- a/XmlEditorUtils/ControlUtils.cs
+++ b/XmlEditorUtils/ControlUtils.cs
@@ -105,6 +105,91 @@ namespace Cinteros.Xrm.XmlEditorUtils
             controls.OfType<Panel>().OrderBy(p => p.TabIndex).ToList().ForEach(p => FillControls(collection, p.Controls, saveable));
         }
 
+        class TextBoxEventHandler
+        {
+            private readonly TextBox txt;
+            private readonly IDefinitionSavable saveable;
+            private bool attachedValidated;
+
+            public TextBoxEventHandler(TextBox txt, IDefinitionSavable saveable)
+            {
+                this.txt = txt;
+                this.saveable = saveable;
+            }
+
+            public void Attach()
+            {
+                txt.TextChanged += OnTextChanged;
+            }
+
+            private void OnTextChanged(object sender, EventArgs e)
+            {
+                saveable.Save(true);
+
+                if (!attachedValidated)
+                {
+                    txt.Validated += OnValidated;
+                    attachedValidated = true;
+                }
+            }
+
+            private void OnValidated(object sender, EventArgs e)
+            {
+                saveable.Save(false);
+                txt.Validated -= OnValidated;
+                attachedValidated = false;
+            }
+        }
+
+        class ComboBoxEventHandler
+        {
+            private readonly ComboBox cmb;
+            private readonly IDefinitionSavable saveable;
+            private bool attachedValidated;
+
+            public ComboBoxEventHandler(ComboBox cmb, IDefinitionSavable saveable)
+            {
+                this.cmb = cmb;
+                this.saveable = saveable;
+            }
+
+            public void Attach()
+            {
+                cmb.TextChanged += OnTextChanged;
+                cmb.SelectedIndexChanged += OnSelectedIndexChanged;
+            }
+
+            private void OnSelectedIndexChanged(object sender, EventArgs e)
+            {
+                saveable.Save(false);
+                cmb.Validated -= OnValidated;
+                attachedValidated = false;
+            }
+
+            private void OnTextChanged(object sender, EventArgs e)
+            {
+                if (cmb.SelectedIndex != -1)
+                {
+                    return;
+                }
+
+                saveable.Save(true);
+
+                if (!attachedValidated)
+                {
+                    cmb.Validated += OnValidated;
+                    attachedValidated = true;
+                }
+            }
+
+            private void OnValidated(object sender, EventArgs e)
+            {
+                saveable.Save(false);
+                cmb.Validated -= OnValidated;
+                attachedValidated = false;
+            }
+        }
+
         public static void FillControl(Dictionary<string, string> collection, Control control, IDefinitionSavable saveable)
         {
             if (control.Tag != null && GetControlDefinition(control, out string attribute, out bool required, out string defaultvalue))
@@ -119,7 +204,7 @@ namespace Cinteros.Xrm.XmlEditorUtils
                     chkbox.Checked = chk;
                     if (saveable != null)
                     {
-                        chkbox.CheckedChanged += (s, e) => saveable.Save(true);
+                        chkbox.CheckedChanged += (s, e) => saveable.Save(false);
                     }
                 }
                 else if (control is TextBox txt)
@@ -127,7 +212,7 @@ namespace Cinteros.Xrm.XmlEditorUtils
                     txt.Text = value;
                     if (saveable != null)
                     {
-                        txt.TextChanged += (s, e) => saveable.Save(true);
+                        new TextBoxEventHandler(txt, saveable).Attach();
                     }
                 }
                 else if (control is ComboBox cmb)
@@ -158,7 +243,7 @@ namespace Cinteros.Xrm.XmlEditorUtils
                     }
                     if (saveable != null)
                     {
-                        cmb.TextChanged += (s, e) => saveable.Save(true);
+                        new ComboBoxEventHandler(cmb, saveable).Attach();
                     }
                 }
             }

--- a/XmlEditorUtils/IDefinitionSavable.cs
+++ b/XmlEditorUtils/IDefinitionSavable.cs
@@ -6,6 +6,6 @@ namespace Cinteros.Xrm.XmlEditorUtils
 {
     public interface IDefinitionSavable
     {
-        bool Save(bool silent);
+        bool Save(bool keyPress);
     }
 }

--- a/XmlEditorUtils/SaveEventArgs.cs
+++ b/XmlEditorUtils/SaveEventArgs.cs
@@ -11,5 +11,7 @@ namespace Cinteros.Xrm.XmlEditorUtils
     public class SaveEventArgs : EventArgs
     {
         public Dictionary<string, string> AttributeCollection { get; set; }
+
+        public bool KeyPress { get; set; }
     }
 }


### PR DESCRIPTION
* Implement `ISupportsInitializeNotification` interface in base control. While control is being initialized, no changes (being triggered by the control being populated) trigger a call to `Save` and so do not appear in the undo history
* A similar process using the `Initializing` field was already added to reduce flicker on the `conditionControl`, so moved this to use the `ISupportsInitializeNotification` mechanism for consistency
* Also use `BeginInit` / `EndInit` to batch multiple changes being made by selecting a relationship so this appears only once
* Added property to `SaveEventArgs` to indicate if change is being triggered by a keypress event or not. Keypress-generated events are ignored from undo history
* Add & remove event handlers as necessary so `Save` event is still triggered on each keypress to update the rest of the UI but adds an extra event handler to `Validated` event to trigger an extra `Save` call when the user finishes editing the field so it can be added to undo history.