### PR TITLE
Do not prevent leaving editor control when there are validation errors

### DIFF
--- a/FetchXmlBuilder/Controls/FetchXmlElementControlBase.cs
+++ b/FetchXmlBuilder/Controls/FetchXmlElementControlBase.cs
@@ -112,7 +112,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
 
             if (RequiresSave())
             {
-                e.Cancel = !Save(false);
+                Save(false);
             }
         }
 


### PR DESCRIPTION
Validation errors are highlighted as they are found, so do not prevent the focus from leaving the editor control.

Resolves #309