### PR TITLE
Multi-select picklist conditions

### DIFF
--- a/FetchXmlBuilder/AppCode/OperatorItem.cs
+++ b/FetchXmlBuilder/AppCode/OperatorItem.cs
@@ -191,6 +191,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
                 case ConditionOperator.InFiscalPeriodAndYear:
                 case ConditionOperator.InOrAfterFiscalPeriodAndYear:
                 case ConditionOperator.InOrBeforeFiscalPeriodAndYear:
+                case ConditionOperator.ContainValues:
+                case ConditionOperator.DoesNotContainValues:
                     result = true;
                     break;
             }
@@ -271,7 +273,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
             return result;
         }
 
-        public static OperatorItem[] GetConditionsByAttributeType(AttributeTypeCode valueType)
+        public static OperatorItem[] GetConditionsByAttributeType(AttributeTypeCode valueType, string attributeTypeName)
         {
             var validConditionsList = new List<OperatorItem>
             {
@@ -403,6 +405,13 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
                     validConditionsList.Add(new OperatorItem(ConditionOperator.EqualUserOrUserHierarchyAndTeams));
                     validConditionsList.Add(new OperatorItem(ConditionOperator.EqualUserOrUserTeams));
                     validConditionsList.Add(new OperatorItem(ConditionOperator.EqualUserTeams));
+                    break;
+                case AttributeTypeCode.Virtual:
+                    if (attributeTypeName == "MultiSelectPicklistType")
+                    {
+                        validConditionsList.Add(new OperatorItem(ConditionOperator.ContainValues));
+                        validConditionsList.Add(new OperatorItem(ConditionOperator.DoesNotContainValues));
+                    }
                     break;
             }
             return validConditionsList.ToArray();

--- a/FetchXmlBuilder/Controls/conditionControl.Designer.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.Designer.cs
@@ -170,7 +170,9 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             "this-year",
             "today",
             "tomorrow",
-            "yesterday"});
+            "yesterday",
+            "contains-values",
+            "not-contains-values"});
             this.cmbOperator.Location = new System.Drawing.Point(7, 96);
             this.cmbOperator.Name = "cmbOperator";
             this.cmbOperator.Size = new System.Drawing.Size(281, 21);

--- a/FetchXmlBuilder/Controls/conditionControl.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.cs
@@ -311,7 +311,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             {
                 //cmbOperator.SelectedItem = null;
                 cmbOperator.Items.Clear();
-                cmbOperator.Items.AddRange(OperatorItem.GetConditionsByAttributeType(attributeType));
+                cmbOperator.Items.AddRange(OperatorItem.GetConditionsByAttributeType(attributeType, attributeItem.Metadata.AttributeTypeName.Value));
                 ReFillControl(cmbOperator);
             }
         }

--- a/FetchXmlBuilder/Controls/valueControl.Designer.cs
+++ b/FetchXmlBuilder/Controls/valueControl.Designer.cs
@@ -29,7 +29,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         private void InitializeComponent()
         {
             this.label2 = new System.Windows.Forms.Label();
-            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.cmbValue = new System.Windows.Forms.ComboBox();
             this.SuspendLayout();
             // 
             // label2
@@ -43,19 +43,21 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             // 
             // textBox1
             // 
-            this.textBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.cmbValue.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBox1.Location = new System.Drawing.Point(7, 16);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(161, 20);
-            this.textBox1.TabIndex = 23;
-            this.textBox1.Tag = "#text|true";
+            this.cmbValue.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.cmbValue.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.cmbValue.Location = new System.Drawing.Point(7, 16);
+            this.cmbValue.Name = "cmbValue";
+            this.cmbValue.Size = new System.Drawing.Size(161, 20);
+            this.cmbValue.TabIndex = 23;
+            this.cmbValue.Tag = "#text|true";
             // 
             // valueControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.textBox1);
+            this.Controls.Add(this.cmbValue);
             this.Controls.Add(this.label2);
             this.Name = "valueControl";
             this.Size = new System.Drawing.Size(171, 47);
@@ -66,6 +68,6 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
 
         #endregion
         private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.ComboBox cmbValue;
     }
 }

--- a/FetchXmlBuilder/Controls/valueControl.cs
+++ b/FetchXmlBuilder/Controls/valueControl.cs
@@ -1,18 +1,86 @@
-﻿using Cinteros.Xrm.FetchXmlBuilder.DockControls;
+﻿using Cinteros.Xrm.FetchXmlBuilder.AppCode;
+using Cinteros.Xrm.FetchXmlBuilder.DockControls;
+using Microsoft.Xrm.Sdk.Metadata;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
 
 namespace Cinteros.Xrm.FetchXmlBuilder.Controls
 {
     public partial class valueControl : FetchXmlElementControlBase
     {
-        public valueControl() : this(null, null)
+        private string _entityName;
+        private string _attributeName;
+
+        public valueControl() : this(null, null, null)
         {
         }
 
-        public valueControl(Dictionary<string, string> collection, TreeBuilderControl tree)
+        public valueControl(TreeNode node, FetchXmlBuilder fetchXmlBuilder, TreeBuilderControl tree)
         {
             InitializeComponent();
-            InitializeFXB(collection, null, tree, null);
+            InitializeFXB(null, fetchXmlBuilder, tree, node);
+
+            _attributeName = TreeNodeHelper.GetAttributeFromNode(Node.Parent, "attribute");
+            _entityName = TreeNodeHelper.GetAttributeFromNode(Node.Parent, "entity");
+
+            if (String.IsNullOrWhiteSpace(_entityName))
+            {
+                _entityName = TreeNodeHelper.GetAttributeFromNode(Node.Parent.Parent.Parent, "name");
+            }
+            else
+            {
+                // TODO: Entity is an alias, get the actual entity name
+            }
+
+            if (fxb.NeedToLoadEntity(_entityName))
+            {
+                if (!fxb.working)
+                {
+                    fxb.LoadEntityDetails(_entityName, RefreshValues);
+                }
+            }
+            else
+            {
+                RefreshValues();
+            }
+        }
+
+        private void RefreshValues()
+        {
+            cmbValue.Items.Clear();
+            cmbValue.DropDownStyle = ComboBoxStyle.Simple;
+
+            var entities = fxb.GetDisplayEntities();
+            if (entities != null && entities.ContainsKey(_entityName))
+            {
+                var entity = entities[_entityName];
+                var attribute = entity.Attributes.SingleOrDefault(a => a.LogicalName == _attributeName);
+
+                if (attribute != null)
+                {
+                    // Show correct editor based on type of attribute
+                    if (attribute is EnumAttributeMetadata enummeta &&
+                         enummeta.OptionSet is OptionSetMetadata options &&
+                         !(attribute is EntityNameAttributeMetadata))
+                    {
+                        cmbValue.Items.AddRange(options.Options.Select(o => new OptionsetItem(o)).ToArray());
+
+                        if (cmbValue.Items.Count > 0 && cmbValue.SelectedIndex == -1 && !string.IsNullOrWhiteSpace(cmbValue.Text))
+                        {
+                            var item = cmbValue.Items.OfType<OptionsetItem>().FirstOrDefault(i => i.GetValue() == cmbValue.Text);
+                            cmbValue.SelectedItem = item;
+                        }
+
+                        cmbValue.DropDownStyle = ComboBoxStyle.DropDownList;
+                    }
+                    else if (attribute is LookupAttributeMetadata lookupmeta)
+                    {
+                        // TODO: Show lookup control
+                    }
+                }
+            }
         }
     }
 }

--- a/FetchXmlBuilder/DockControls/TreeBuilderControl.cs
+++ b/FetchXmlBuilder/DockControls/TreeBuilderControl.cs
@@ -621,7 +621,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.DockControls
                             break;
 
                         case "value":
-                            ctrl = new valueControl(collec, this);
+                            ctrl = new valueControl(node, fxb, this);
                             break;
 
                         case "#comment":


### PR DESCRIPTION
* Adds support for the `contains-values` and `does-not-contain-values` condition operators for multi-select picklist values.
* Adds picklist value dropdown helper for `<value>` element editor, which can be used for multi-select and regular picklist fields.

Fixes #273 