### PR TITLE
Expose <condition valueof> attribute

### DIFF
--- a/FetchXmlBuilder/AppCode/OData4CodeGenerator.cs
+++ b/FetchXmlBuilder/AppCode/OData4CodeGenerator.cs
@@ -666,6 +666,10 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
 
                     result += FormatValue(valueType, condition.value);
                 }
+                else if (!string.IsNullOrEmpty(condition.valueof))
+                {
+                    result += condition.valueof;
+                }
             }
             return result;
         }

--- a/FetchXmlBuilder/AppCode/TreeNodeHelper.cs
+++ b/FetchXmlBuilder/AppCode/TreeNodeHelper.cs
@@ -175,6 +175,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
                         var attr = GetAttributeFromNode(node, "attribute");
                         var oper = GetAttributeFromNode(node, "operator");
                         var val = GetAttributeFromNode(node, "value");
+                        var valueOf = GetAttributeFromNode(node, "valueof");
                         var uiname = GetAttributeFromNode(node, "uiname");
                         if (node.Parent != null && node.Parent.Parent != null)
                         {
@@ -193,6 +194,10 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
                         if (!string.IsNullOrWhiteSpace(uiname) && fxb.settings.UseFriendlyNames)
                         {
                             val = uiname;
+                        }
+                        if (!string.IsNullOrWhiteSpace(valueOf))
+                        {
+                            val = valueOf;
                         }
                         text += (" " + attr + " " + oper + " " + val).TrimEnd();
                     }

--- a/FetchXmlBuilder/Controls/conditionControl.Designer.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.Designer.cs
@@ -52,12 +52,16 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             this.panGuidSelector = new System.Windows.Forms.Panel();
             this.rbEnterGuid = new System.Windows.Forms.RadioButton();
             this.rbUseLookup = new System.Windows.Forms.RadioButton();
+            this.panValueOf = new System.Windows.Forms.Panel();
+            this.cmbValueOf = new System.Windows.Forms.ComboBox();
+            this.label6 = new System.Windows.Forms.Label();
             this.panAttribte.SuspendLayout();
             this.panValue.SuspendLayout();
             this.panValueLookup.SuspendLayout();
             this.panValueHint.SuspendLayout();
             this.panUitype.SuspendLayout();
             this.panGuidSelector.SuspendLayout();
+            this.panValueOf.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this)).BeginInit();
             this.SuspendLayout();
             // 
@@ -396,12 +400,46 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             this.rbUseLookup.UseVisualStyleBackColor = true;
             this.rbUseLookup.CheckedChanged += new System.EventHandler(this.rbUseLookup_CheckedChanged);
             // 
+            // panValueOf
+            // 
+            this.panValueOf.Controls.Add(this.cmbValueOf);
+            this.panValueOf.Controls.Add(this.label6);
+            this.panValueOf.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panValueOf.Location = new System.Drawing.Point(0, 303);
+            this.panValueOf.Name = "panValueOf";
+            this.panValueOf.Size = new System.Drawing.Size(311, 40);
+            this.panValueOf.TabIndex = 50;
+            // 
+            // cmbValueOf
+            // 
+            this.cmbValueOf.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.cmbValueOf.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.cmbValueOf.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.cmbValueOf.FormattingEnabled = true;
+            this.cmbValueOf.Location = new System.Drawing.Point(7, 16);
+            this.cmbValueOf.Name = "cmbValueOf";
+            this.cmbValueOf.Size = new System.Drawing.Size(281, 21);
+            this.cmbValueOf.Sorted = true;
+            this.cmbValueOf.TabIndex = 32;
+            this.cmbValueOf.Tag = "valueof";
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(4, 2);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(48, 13);
+            this.label6.TabIndex = 31;
+            this.label6.Text = "Value Of";
+            // 
             // conditionControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.panUitype);
             this.Controls.Add(this.panValueHint);
+            this.Controls.Add(this.panValueOf);
             this.Controls.Add(this.panGuidSelector);
             this.Controls.Add(this.panValueLookup);
             this.Controls.Add(this.panValue);
@@ -420,6 +458,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             this.panUitype.PerformLayout();
             this.panGuidSelector.ResumeLayout(false);
             this.panGuidSelector.PerformLayout();
+            this.panValueOf.ResumeLayout(false);
+            this.panValueOf.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this)).EndInit();
             this.ResumeLayout(false);
 
@@ -449,5 +489,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
         private System.Windows.Forms.Panel panGuidSelector;
         private System.Windows.Forms.RadioButton rbEnterGuid;
         private System.Windows.Forms.RadioButton rbUseLookup;
+        private System.Windows.Forms.Panel panValueOf;
+        private System.Windows.Forms.ComboBox cmbValueOf;
+        private System.Windows.Forms.Label label6;
     }
 }

--- a/FetchXmlBuilder/Controls/conditionControl.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.cs
@@ -452,31 +452,35 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                 panValueLookup.Visible = rbUseLookup.Checked;
             }
 
-            switch (oper.GetValue())
+            if (string.IsNullOrWhiteSpace(cmbEntity.Text))
             {
-                case "eq":
-                case "ne":
-                case "gt":
-                case "ge":
-                case "lt":
-                case "le":
-                    panValueOf.Visible = true;
-                    cmbValueOf.Items.Clear();
-                    if (attribute != null)
-                    {
-                        foreach (AttributeItem item in cmbAttribute.Items)
+                switch (oper.GetValue())
+                {
+                    case "eq":
+                    case "ne":
+                    case "gt":
+                    case "ge":
+                    case "lt":
+                    case "le":
+                        panValueOf.Visible = true;
+                        cmbValueOf.Items.Clear();
+                        if (attribute != null)
                         {
-                            if (item.Metadata.AttributeType == attribute.Metadata.AttributeType)
+                            foreach (AttributeItem item in cmbAttribute.Items)
                             {
-                                cmbValueOf.Items.Add(new AttributeItem(item.Metadata));
+                                if (item.Metadata.AttributeType == attribute.Metadata.AttributeType)
+                                {
+                                    cmbValueOf.Items.Add(new AttributeItem(item.Metadata));
+                                }
                             }
                         }
-                    }
-                    break;
+                        break;
+                }
+            }
 
-                default:
-                    cmbValueOf.Text = "";
-                    break;
+            if (!panValueOf.Visible)
+            {
+                cmbValueOf.Text = "";
             }
         }
 

--- a/FetchXmlBuilder/Controls/conditionControl.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.cs
@@ -150,6 +150,11 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
 
                     if (control == cmbValue)
                     {
+                        if (!string.IsNullOrWhiteSpace(cmbValueOf.Text) && !string.IsNullOrWhiteSpace(cmbValue.Text))
+                        {
+                            return new ControlValidationResult(ControlValidationLevel.Error, "Value and Value Of cannot both be set");
+                        }
+
                         switch (valueType)
                         {
                             case null:
@@ -296,6 +301,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             // RefreshFill now that attributes are loaded
             ReFillControl(cmbAttribute);
             ReFillControl(cmbValue);
+            ReFillControl(cmbValueOf);
             EndInit();
             RefreshOperators();
             UpdateValueField();
@@ -323,6 +329,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                 return;
             }
             panValue.Visible = true;
+            panValueOf.Visible = false;
             panValueLookup.Visible = false;
             panGuidSelector.Visible = false;
             cmbValue.Items.Clear();
@@ -443,6 +450,33 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                 panGuidSelector.Visible = true;
                 panValue.Visible = !rbUseLookup.Checked;
                 panValueLookup.Visible = rbUseLookup.Checked;
+            }
+
+            switch (oper.GetValue())
+            {
+                case "eq":
+                case "ne":
+                case "gt":
+                case "ge":
+                case "lt":
+                case "le":
+                    panValueOf.Visible = true;
+                    cmbValueOf.Items.Clear();
+                    if (attribute != null)
+                    {
+                        foreach (AttributeItem item in cmbAttribute.Items)
+                        {
+                            if (item.Metadata.AttributeType == attribute.Metadata.AttributeType)
+                            {
+                                cmbValueOf.Items.Add(new AttributeItem(item.Metadata));
+                            }
+                        }
+                    }
+                    break;
+
+                default:
+                    cmbValueOf.Text = "";
+                    break;
             }
         }
 

--- a/FetchXmlBuilder/Resources/fetch.cs
+++ b/FetchXmlBuilder/Resources/fetch.cs
@@ -83,6 +83,10 @@ namespace Cinteros.Xrm.FetchXmlBuilder {
         /// <remarks/>
         [System.Xml.Serialization.XmlIgnoreAttribute()]
         public bool uihiddenSpecified;
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string valueof;
     }
     
     /// <remarks/>


### PR DESCRIPTION
* Adds an option to select another attribute to compare to in the condition editor
* Validates that only the Value or Value Of options are populated, not both
* The new Value Of combobox is only shown when one of the supported operators is selected
* Conversion to OData4 / Power Automate is supported
* Conversion to QueryExpression is not supported, as the service currently seems to hang while executing the `FetchXmlToQueryExpressionRequest`

Fixes #338 