### PR TITLE
EntityName attribute conditions

### DIFF
--- a/FetchXmlBuilder/AppCode/EntityNameItem.cs
+++ b/FetchXmlBuilder/AppCode/EntityNameItem.cs
@@ -1,0 +1,25 @@
+﻿using Cinteros.Xrm.XmlEditorUtils;
+using Microsoft.Xrm.Sdk.Metadata;
+
+namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
+{
+    public class EntityNameItem : IComboBoxItem
+    {
+        private EntityMetadata meta = null;
+
+        public EntityNameItem(EntityMetadata Entity)
+        {
+            meta = Entity;
+        }
+
+        public override string ToString()
+        {
+            return FetchXmlBuilder.GetEntityDisplayName(meta);
+        }
+
+        public string GetValue()
+        {
+            return meta.ObjectTypeCode.Value.ToString();
+        }
+    }
+}

--- a/FetchXmlBuilder/AppCode/OperatorItem.cs
+++ b/FetchXmlBuilder/AppCode/OperatorItem.cs
@@ -315,7 +315,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
                 valueType != AttributeTypeCode.Lookup &&
                 valueType != AttributeTypeCode.Customer &&
                 valueType != AttributeTypeCode.Owner &&
-                valueType != AttributeTypeCode.Uniqueidentifier)
+                valueType != AttributeTypeCode.Uniqueidentifier &&
+                valueType != AttributeTypeCode.EntityName)
             {
                 validConditionsList.Add(new OperatorItem(ConditionOperator.BeginsWith));
                 validConditionsList.Add(new OperatorItem(ConditionOperator.DoesNotBeginWith));

--- a/FetchXmlBuilder/Controls/conditionControl.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.cs
@@ -361,18 +361,19 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                          !(attribute.Metadata is EntityNameAttributeMetadata))
                 {
                     cmbValue.Items.AddRange(options.Options.Select(o => new OptionsetItem(o)).ToArray());
+                    var value = cmbValue.Text;
                     cmbValue.DropDownStyle = ComboBoxStyle.DropDownList;
+                    cmbValue.SelectedItem = cmbValue.Items.OfType<OptionsetItem>().FirstOrDefault(i => i.GetValue() == value);
                 }
                 else if (attribute.Metadata is EntityNameAttributeMetadata)
                 {
                     var entities = fxb.GetDisplayEntities();
                     if (entities != null)
                     {
-                        foreach (var entity in entities)
-                        {
-                            cmbValue.Items.Add(new EntityNameItem(entity.Value));
-                        }
+                        cmbValue.Items.AddRange(entities.Select(e => new EntityNameItem(e.Value)).ToArray());
+                        var value = cmbValue.Text;
                         cmbValue.DropDownStyle = ComboBoxStyle.DropDownList;
+                        cmbValue.SelectedItem = cmbValue.Items.OfType<EntityNameItem>().FirstOrDefault(i => i.GetValue() == value);
                     }
                 }
                 else if (attribute.Metadata is LookupAttributeMetadata lookupmeta)
@@ -413,6 +414,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                     }
                 }
             }
+
             if (valueType == null)
             {
                 cmbValue.Text = "";
@@ -421,13 +423,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
             else
             {
                 cmbValue.Enabled = true;
-
-                if (cmbValue.Items.Count > 0 && cmbValue.SelectedIndex == -1 && !string.IsNullOrWhiteSpace(cmbValue.Text))
-                {
-                    var item = cmbValue.Items.OfType<OptionsetItem>().FirstOrDefault(i => i.ToString() == cmbValue.Text);
-                    cmbValue.SelectedItem = item;
-                }
             }
+
             if (valueType == AttributeTypeCode.Lookup ||
                 valueType == AttributeTypeCode.Customer ||
                 valueType == AttributeTypeCode.Owner ||

--- a/FetchXmlBuilder/Controls/conditionControl.cs
+++ b/FetchXmlBuilder/Controls/conditionControl.cs
@@ -181,6 +181,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                             case AttributeTypeCode.Status:
                             case AttributeTypeCode.Picklist:
                             case AttributeTypeCode.BigInt:
+                            case AttributeTypeCode.EntityName:
                                 int intvalue;
                                 if (!int.TryParse(value, out intvalue))
                                 {
@@ -208,7 +209,6 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                                 break;
                             case AttributeTypeCode.String:
                             case AttributeTypeCode.Memo:
-                            case AttributeTypeCode.EntityName:
                             case AttributeTypeCode.Virtual:
                                 break;
                             case AttributeTypeCode.PartyList:
@@ -362,6 +362,18 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Controls
                 {
                     cmbValue.Items.AddRange(options.Options.Select(o => new OptionsetItem(o)).ToArray());
                     cmbValue.DropDownStyle = ComboBoxStyle.DropDownList;
+                }
+                else if (attribute.Metadata is EntityNameAttributeMetadata)
+                {
+                    var entities = fxb.GetDisplayEntities();
+                    if (entities != null)
+                    {
+                        foreach (var entity in entities)
+                        {
+                            cmbValue.Items.Add(new EntityNameItem(entity.Value));
+                        }
+                        cmbValue.DropDownStyle = ComboBoxStyle.DropDownList;
+                    }
                 }
                 else if (attribute.Metadata is LookupAttributeMetadata lookupmeta)
                 {

--- a/FetchXmlBuilder/FetchXmlBuilder.csproj
+++ b/FetchXmlBuilder/FetchXmlBuilder.csproj
@@ -182,6 +182,7 @@
   <ItemGroup>
     <Compile Include="AppCode\AppInsights.cs" />
     <Compile Include="AppCode\ConnectionExtensions.cs" />
+    <Compile Include="AppCode\EntityNameItem.cs" />
     <Compile Include="AppCode\ServiceExtensions.cs" />
     <Compile Include="AppCode\AttributeItem.cs" />
     <Compile Include="AppCode\CodeGeneratorBase.cs" />


### PR DESCRIPTION
`EntityName` attributes (e.g. `listmember.entitytype`) are returned as strings, but need to passed as the corresponding ObjectTypeCode integer for conditions.

This PR produces a drop down list interface similar to optionset attributes to show a list of the available entities and supply the correct value.

There also seems to be an error causing the optionset drop down list not to be shown correctly when it is first selected and it needs to load the metadata, this attempts to address this.