### PR TITLE
OData fixes

### DIFF
--- a/FetchXmlBuilder/AppCode/OData4CodeGenerator.cs
+++ b/FetchXmlBuilder/AppCode/OData4CodeGenerator.cs
@@ -382,7 +382,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
                         functionParameters = Int32.MaxValue;
                         break;
                     case @operator.containvalues:
-                        function = "ContainsValues";
+                        function = "ContainValues";
                         functionParameters = Int32.MaxValue;
                         break;
                     case @operator.notcontainvalues:

--- a/FetchXmlBuilder/AppCode/OData4CodeGenerator.cs
+++ b/FetchXmlBuilder/AppCode/OData4CodeGenerator.cs
@@ -345,16 +345,31 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
                         result += " ne null";
                         break;
                     case @operator.like:
-                        result = $"contains({HttpUtility.UrlEncode(attrMeta.LogicalName)}, '{HttpUtility.UrlEncode(condition.value)}')";
-                        break;
                     case @operator.notlike:
-                        result = $"not contains({HttpUtility.UrlEncode(attrMeta.LogicalName)}, '{HttpUtility.UrlEncode(condition.value)}')";
+                        result = $"contains({HttpUtility.UrlEncode(attrMeta.LogicalName)}, {FormatValue(typeof(string), condition.value)})";
+
+                        if (condition.@operator == @operator.notlike)
+                        {
+                            result = "not " + result;
+                        }
                         break;
                     case @operator.beginswith:
-                        result = $"startswith({HttpUtility.UrlEncode(attrMeta.LogicalName)}, '{HttpUtility.UrlEncode(condition.value)}')";
+                    case @operator.notbeginwith:
+                        result = $"startswith({HttpUtility.UrlEncode(attrMeta.LogicalName)}, {FormatValue(typeof(string), condition.value)})";
+
+                        if (condition.@operator == @operator.notbeginwith)
+                        {
+                            result = "not " + result;
+                        }
                         break;
                     case @operator.endswith:
-                        result = $"endswith({HttpUtility.UrlEncode(attrMeta.LogicalName)}, '{HttpUtility.UrlEncode(condition.value)}')";
+                    case @operator.notendwith:
+                        result = $"endswith({HttpUtility.UrlEncode(attrMeta.LogicalName)}, {FormatValue(typeof(string), condition.value)})";
+
+                        if (condition.@operator == @operator.notendwith)
+                        {
+                            result = "not " + result;
+                        }
                         break;
                     case @operator.above:
                         function = "Above";

--- a/FetchXmlBuilder/DockControls/FlowListControl.Designer.cs
+++ b/FetchXmlBuilder/DockControls/FlowListControl.Designer.cs
@@ -105,6 +105,7 @@
             this.linkSelect.TabStop = true;
             this.linkSelect.Tag = "Select formula";
             this.linkSelect.Text = "N/A";
+            this.linkSelect.UseMnemonic = false;
             this.linkSelect.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // lblCopied
@@ -141,6 +142,7 @@
             this.linkExpand.TabStop = true;
             this.linkExpand.Tag = "Expand Query";
             this.linkExpand.Text = "N/A";
+            this.linkExpand.UseMnemonic = false;
             this.linkExpand.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // linkTop
@@ -156,6 +158,7 @@
             this.linkTop.TabStop = true;
             this.linkTop.Tag = "Top Count";
             this.linkTop.Text = "N/A";
+            this.linkTop.UseMnemonic = false;
             this.linkTop.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // linkOrder
@@ -171,6 +174,7 @@
             this.linkOrder.TabStop = true;
             this.linkOrder.Tag = "Order By";
             this.linkOrder.Text = "N/A";
+            this.linkOrder.UseMnemonic = false;
             this.linkOrder.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // linkFilter
@@ -186,6 +190,7 @@
             this.linkFilter.TabStop = true;
             this.linkFilter.Tag = "Filter Query";
             this.linkFilter.Text = "N/A";
+            this.linkFilter.UseMnemonic = false;
             this.linkFilter.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // label5


### PR DESCRIPTION
Fixes errors in the OData4 / Power Automate URLs from #361 and #362:

* FetchXML queries with multiple non-nested `<filter>` elements were missing an `and` operator
* Condition values that contained special URL characters were not correctly escaped