### PR TITLE
Fix #358: 'Copy Headers' option state isn't updated when updating selection.

### DIFF
--- a/FetchXmlBuilder/DockControls/ResultGrid.Designer.cs
+++ b/FetchXmlBuilder/DockControls/ResultGrid.Designer.cs
@@ -160,7 +160,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.DockControls
             this.mnuCopyHeaders.CheckOnClick = true;
             this.mnuCopyHeaders.Name = "mnuCopyHeaders";
             this.mnuCopyHeaders.Size = new System.Drawing.Size(180, 22);
-            this.mnuCopyHeaders.Text = "Copy with Headers";
+            this.mnuCopyHeaders.Text = "Copy with Headers";            
+            this.mnuCopyHeaders.Click += new System.EventHandler(this.chkGridOptions_Click);
             // 
             // mnuColumns
             // 


### PR DESCRIPTION
It appears that the click handler was missing from the "Copy Headers" option. This PR should address #358.