### PR TITLE
Web API updates

### DIFF
--- a/FetchXmlBuilder/AppCode/OData4CodeGenerator.cs
+++ b/FetchXmlBuilder/AppCode/OData4CodeGenerator.cs
@@ -218,10 +218,15 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
             {
                 var currentLinkEntity = linkEntity;
                 var expand = new LinkEntityOData();
-                expand.PropertyName = LinkItemToNavigationProperty(entityName, currentLinkEntity, fxb, out _, out var manyToManyNextLink);
+                expand.PropertyName = LinkItemToNavigationProperty(entityName, currentLinkEntity, fxb, out var child, out var manyToManyNextLink);
                 currentLinkEntity = manyToManyNextLink ?? currentLinkEntity;
                 expand.Select.AddRange(ConvertSelect(currentLinkEntity.name, currentLinkEntity.Items, fxb));
-                expand.Filter.AddRange(ConvertFilters(currentLinkEntity.name, currentLinkEntity.Items, fxb, rootEntityItems));
+
+                if (linkEntity.linktype == "outer" || child)
+                {
+                    // Don't need to add filters at this point for single-valued properties in inner joins, they'll be added separately later
+                    expand.Filter.AddRange(ConvertFilters(currentLinkEntity.name, currentLinkEntity.Items, fxb, rootEntityItems));
+                }
 
                 // Recurse into child joins
                 expand.Expand.AddRange(ConvertJoins(currentLinkEntity.name, currentLinkEntity.Items, fxb, rootEntityItems));


### PR DESCRIPTION
## Implements inner joins

For single-value properties (e.g. parental lookups), this converts a query such as

```xml
<fetch >
  <entity name="account" >
    <attribute name="name" />
    <link-entity name="contact" from="contactid" to="primarycontactid" >
      <attribute name="fullname" />
      <filter>
        <condition attribute="firstname" operator="eq" value="Mark" />
      </filter>
    </link-entity>
  </entity>
</fetch>
```

to a filter like:

```
/accounts?$select=name&$expand=primarycontactid($select=fullname)&$filter=(primarycontactid/firstname eq 'Mark')
```

If the join type is changed to `outer`, the filter is moved inside the `$expand` option, so the account record is returned but the contact is only expanded if it meets the criteria:

```
/accounts?$select=name&$expand=primarycontactid($select=fullname;$filter=(firstname eq 'Mark'))
```

For multi-valued collections (e.g. child entities), this converts a query such as

```xml
<fetch >
  <entity name="account" >
    <attribute name="name" />
    <link-entity name="contact" from="parentcustomerid" to="accountid" >
      <attribute name="fullname" />
      <filter>
        <condition attribute="firstname" operator="eq" value="Mark" />
      </filter>
    </link-entity>
  </entity>
</fetch>
```

to a filter like:

```
/accounts?$select=name&$expand=contact_customer_accounts($select=fullname;$filter=(firstname eq 'Mark'))&$filter=(contact_customer_accounts/any(o1:(o1/firstname eq 'Mark')))
```

i.e. it expands the list of contacts that match the filter, but only for accounts that have at least one contact that matches the same filter.

Changing it to an outer join removes the additional `$filter` option:

```
/accounts?$select=name&$expand=contact_customer_accounts($select=fullname;$filter=(firstname eq 'Mark'))
```

## Refactoring

The code previously did a lot of simple string concatenation which was becoming unmaintainable as we try to support more complex queries. I've refactored a lot of this into a more structured approach to try to help. This obviously brings some risk of breaking previously working queries.

I've tested the examples from #359 and I believe they still generate valid queries, but I'd appreciate any extra testing before merging.