### PR TITLE
JSON formatting options

### DIFF
--- a/FetchXmlBuilder/AppCode/FXBSettings.cs
+++ b/FetchXmlBuilder/AppCode/FXBSettings.cs
@@ -214,6 +214,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
         Grid = 0,
         XML = 1,
         JSON = 2,
-        Raw = 3
+        Raw = 3,
+        JSONWebAPI = 4
     }
 }

--- a/FetchXmlBuilder/FetchXmlBuilder.cs
+++ b/FetchXmlBuilder/FetchXmlBuilder.cs
@@ -530,6 +530,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder
                 case ResultOutput.Grid:
                 case ResultOutput.XML:
                 case ResultOutput.JSON:
+                case ResultOutput.JSONWebAPI:
                     RetrieveMultiple(fetch);
                     break;
 
@@ -1502,7 +1503,12 @@ namespace Cinteros.Xrm.FetchXmlBuilder
                     ai.WriteEvent("RetrieveMultiple", resultCollection?.Entities?.Count, (DateTime.Now - start).TotalMilliseconds, HandleAIResult);
                     if (settings.Results.ResultOutput == ResultOutput.JSON)
                     {
-                        var json = EntityCollectionSerializer.ToJSON(resultCollection, Formatting.Indented);
+                        var json = EntityCollectionSerializer.ToJSON(resultCollection, Formatting.Indented, JsonFormat.Legacy);
+                        eventargs.Result = json;
+                    }
+                    else if (settings.Results.ResultOutput == ResultOutput.JSONWebAPI)
+                    {
+                        var json = EntityCollectionSerializer.ToJSON(resultCollection, Formatting.Indented, JsonFormat.WebApi);
                         eventargs.Result = json;
                     }
                     else
@@ -1565,7 +1571,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder
                                 break;
                         }
                     }
-                    else if (settings.Results.ResultOutput == ResultOutput.JSON && completedargs.Result is string json)
+                    else if ((settings.Results.ResultOutput == ResultOutput.JSON || settings.Results.ResultOutput == ResultOutput.JSONWebAPI) && completedargs.Result is string json)
                     {
                         ShowResultControl(json, ContentType.Serialized_Result_JSON, SaveFormat.JSON, settings.DockStates.FetchResult);
                     }

--- a/FetchXmlBuilder/FetchXmlBuilder.csproj
+++ b/FetchXmlBuilder/FetchXmlBuilder.csproj
@@ -163,8 +163,9 @@
     <Reference Include="WeifenLuo.WinFormsUI.Docking.ThemeVS2015, Version=3.0.6.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
       <HintPath>..\packages\DockPanelSuite.ThemeVS2015.3.0.6\lib\net40\WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll</HintPath>
     </Reference>
-    <Reference Include="xrmtb.XrmToolBox.Controls, Version=2.2.4.0, Culture=neutral, PublicKeyToken=34def2c40500c62c, processorArchitecture=MSIL">
+    <Reference Include="xrmtb.XrmToolBox.Controls, Version=1.2020.5.7, Culture=neutral, PublicKeyToken=34def2c40500c62c, processorArchitecture=MSIL">
       <HintPath>..\packages\xrmtb.XrmToolBox.Controls.2.2.4\lib\net47\xrmtb.XrmToolBox.Controls.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="XrmToolBox, Version=1.2020.11.42, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\XrmToolBoxPackage.1.2020.11.42\lib\net462\XrmToolBox.exe</HintPath>

--- a/FetchXmlBuilder/FetchXmlBuilder.csproj
+++ b/FetchXmlBuilder/FetchXmlBuilder.csproj
@@ -163,9 +163,8 @@
     <Reference Include="WeifenLuo.WinFormsUI.Docking.ThemeVS2015, Version=3.0.6.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
       <HintPath>..\packages\DockPanelSuite.ThemeVS2015.3.0.6\lib\net40\WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll</HintPath>
     </Reference>
-    <Reference Include="xrmtb.XrmToolBox.Controls, Version=1.2020.5.7, Culture=neutral, PublicKeyToken=34def2c40500c62c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xrmtb.XrmToolBox.Controls.2.2.4\lib\net47\xrmtb.XrmToolBox.Controls.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="xrmtb.XrmToolBox.Controls, Version=2.2.10.0, Culture=neutral, PublicKeyToken=34def2c40500c62c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xrmtb.XrmToolBox.Controls.2.2.10\lib\net47\xrmtb.XrmToolBox.Controls.dll</HintPath>
     </Reference>
     <Reference Include="XrmToolBox, Version=1.2020.11.42, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\XrmToolBoxPackage.1.2020.11.42\lib\net462\XrmToolBox.exe</HintPath>

--- a/FetchXmlBuilder/Forms/Settings.Designer.cs
+++ b/FetchXmlBuilder/Forms/Settings.Designer.cs
@@ -61,6 +61,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             this.chkAppResultsNewWindow = new System.Windows.Forms.CheckBox();
             this.chkResAllPages = new System.Windows.Forms.CheckBox();
             this.gbAppearance = new System.Windows.Forms.GroupBox();
+            this.chkShowButtonTexts = new System.Windows.Forms.CheckBox();
             this.chkShowHelp = new System.Windows.Forms.CheckBox();
             this.chkUseLookup = new System.Windows.Forms.CheckBox();
             this.chkAppAllowUncustViews = new System.Windows.Forms.CheckBox();
@@ -82,7 +83,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             this.propXmlColors = new System.Windows.Forms.PropertyGrid();
             this.gbBehavior = new System.Windows.Forms.GroupBox();
             this.chkAddConditionToFilter = new System.Windows.Forms.CheckBox();
-            this.chkShowButtonTexts = new System.Windows.Forms.CheckBox();
+            this.rbResSerializedJSONWebAPI = new System.Windows.Forms.RadioButton();
             this.gbEntities.SuspendLayout();
             this.gbAttributes.SuspendLayout();
             this.gbResult.SuspendLayout();
@@ -372,13 +373,14 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             // 
             // gbResult
             // 
+            this.gbResult.Controls.Add(this.rbResSerializedJSONWebAPI);
             this.gbResult.Controls.Add(this.rbResSerializedJSON);
             this.gbResult.Controls.Add(this.rbResRaw);
             this.gbResult.Controls.Add(this.rbResSerializedXML);
             this.gbResult.Controls.Add(this.rbResGrid);
             this.gbResult.Location = new System.Drawing.Point(239, 12);
             this.gbResult.Name = "gbResult";
-            this.gbResult.Size = new System.Drawing.Size(222, 105);
+            this.gbResult.Size = new System.Drawing.Size(222, 125);
             this.gbResult.TabIndex = 3;
             this.gbResult.TabStop = false;
             this.gbResult.Text = "Result view";
@@ -386,17 +388,17 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             // rbResSerializedJSON
             // 
             this.rbResSerializedJSON.AutoSize = true;
-            this.rbResSerializedJSON.Location = new System.Drawing.Point(15, 60);
+            this.rbResSerializedJSON.Location = new System.Drawing.Point(12, 59);
             this.rbResSerializedJSON.Name = "rbResSerializedJSON";
-            this.rbResSerializedJSON.Size = new System.Drawing.Size(101, 17);
+            this.rbResSerializedJSON.Size = new System.Drawing.Size(180, 17);
             this.rbResSerializedJSON.TabIndex = 3;
-            this.rbResSerializedJSON.Text = "Serialized JSON";
+            this.rbResSerializedJSON.Text = "Serialized JSON - Legacy Format";
             this.rbResSerializedJSON.UseVisualStyleBackColor = true;
             // 
             // rbResRaw
             // 
             this.rbResRaw.AutoSize = true;
-            this.rbResRaw.Location = new System.Drawing.Point(16, 80);
+            this.rbResRaw.Location = new System.Drawing.Point(12, 99);
             this.rbResRaw.Name = "rbResRaw";
             this.rbResRaw.Size = new System.Drawing.Size(102, 17);
             this.rbResRaw.TabIndex = 4;
@@ -406,7 +408,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             // rbResSerializedXML
             // 
             this.rbResSerializedXML.AutoSize = true;
-            this.rbResSerializedXML.Location = new System.Drawing.Point(16, 40);
+            this.rbResSerializedXML.Location = new System.Drawing.Point(12, 39);
             this.rbResSerializedXML.Name = "rbResSerializedXML";
             this.rbResSerializedXML.Size = new System.Drawing.Size(95, 17);
             this.rbResSerializedXML.TabIndex = 2;
@@ -417,7 +419,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             // 
             this.rbResGrid.AutoSize = true;
             this.rbResGrid.Checked = true;
-            this.rbResGrid.Location = new System.Drawing.Point(16, 20);
+            this.rbResGrid.Location = new System.Drawing.Point(12, 19);
             this.rbResGrid.Name = "rbResGrid";
             this.rbResGrid.Size = new System.Drawing.Size(48, 17);
             this.rbResGrid.TabIndex = 1;
@@ -459,6 +461,16 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             this.gbAppearance.TabIndex = 1;
             this.gbAppearance.TabStop = false;
             this.gbAppearance.Text = "Appearance";
+            // 
+            // chkShowButtonTexts
+            // 
+            this.chkShowButtonTexts.AutoSize = true;
+            this.chkShowButtonTexts.Location = new System.Drawing.Point(16, 120);
+            this.chkShowButtonTexts.Name = "chkShowButtonTexts";
+            this.chkShowButtonTexts.Size = new System.Drawing.Size(111, 17);
+            this.chkShowButtonTexts.TabIndex = 10;
+            this.chkShowButtonTexts.Text = "Show button texts";
+            this.chkShowButtonTexts.UseVisualStyleBackColor = true;
             // 
             // chkShowHelp
             // 
@@ -645,7 +657,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             // 
             this.gbXml.Controls.Add(this.btnResetXmlColors);
             this.gbXml.Controls.Add(this.propXmlColors);
-            this.gbXml.Location = new System.Drawing.Point(239, 123);
+            this.gbXml.Location = new System.Drawing.Point(240, 143);
             this.gbXml.Name = "gbXml";
             this.gbXml.Size = new System.Drawing.Size(222, 145);
             this.gbXml.TabIndex = 4;
@@ -713,15 +725,15 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             this.chkAddConditionToFilter.Text = "Add Condition to Filter automatically";
             this.chkAddConditionToFilter.UseVisualStyleBackColor = true;
             // 
-            // chkShowButtonTexts
+            // rbResSerializedJSONWebAPI
             // 
-            this.chkShowButtonTexts.AutoSize = true;
-            this.chkShowButtonTexts.Location = new System.Drawing.Point(16, 120);
-            this.chkShowButtonTexts.Name = "chkShowButtonTexts";
-            this.chkShowButtonTexts.Size = new System.Drawing.Size(111, 17);
-            this.chkShowButtonTexts.TabIndex = 10;
-            this.chkShowButtonTexts.Text = "Show button texts";
-            this.chkShowButtonTexts.UseVisualStyleBackColor = true;
+            this.rbResSerializedJSONWebAPI.AutoSize = true;
+            this.rbResSerializedJSONWebAPI.Location = new System.Drawing.Point(12, 79);
+            this.rbResSerializedJSONWebAPI.Name = "rbResSerializedJSONWebAPI";
+            this.rbResSerializedJSONWebAPI.Size = new System.Drawing.Size(188, 17);
+            this.rbResSerializedJSONWebAPI.TabIndex = 5;
+            this.rbResSerializedJSONWebAPI.Text = "Serialized JSON - Web API Format";
+            this.rbResSerializedJSONWebAPI.UseVisualStyleBackColor = true;
             // 
             // Settings
             // 
@@ -814,5 +826,6 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         private System.Windows.Forms.CheckBox chkShowHelp;
         private System.Windows.Forms.CheckBox chkAddConditionToFilter;
         private System.Windows.Forms.CheckBox chkShowButtonTexts;
+        private System.Windows.Forms.RadioButton rbResSerializedJSONWebAPI;
     }
 }

--- a/FetchXmlBuilder/Forms/Settings.cs
+++ b/FetchXmlBuilder/Forms/Settings.cs
@@ -35,6 +35,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             {
                 case ResultOutput.XML: rbResSerializedXML.Checked = true; break;
                 case ResultOutput.JSON: rbResSerializedJSON.Checked = true; break;
+                case ResultOutput.JSONWebAPI: rbResSerializedJSONWebAPI.Checked = true; break;
                 case ResultOutput.Raw: rbResRaw.Checked = true; break;
                 default: rbResGrid.Checked = true; break;
             }
@@ -77,7 +78,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             settings.QueryOptions.NewQueryTemplate = txtFetch.Text;
             settings.DoNotPromptToSave = chkAppNoSavePrompt.Checked;
             settings.Results.AlwaysNewWindow = chkAppResultsNewWindow.Checked;
-            settings.Results.ResultOutput = rbResSerializedXML.Checked ? ResultOutput.XML : rbResSerializedJSON.Checked ? ResultOutput.JSON : rbResRaw.Checked ? ResultOutput.Raw : ResultOutput.Grid;
+            settings.Results.ResultOutput = rbResSerializedXML.Checked ? ResultOutput.XML : rbResSerializedJSON.Checked ? ResultOutput.JSON : rbResRaw.Checked ? ResultOutput.Raw : rbResSerializedJSONWebAPI.Checked ? ResultOutput.JSONWebAPI : ResultOutput.Grid;
             settings.Results.RetrieveAllPages = chkResAllPages.Checked;
             settings.OpenUncustomizableViews = chkAppAllowUncustViews.Checked;
             settings.AddConditionToFilter = chkAddConditionToFilter.Checked;

--- a/FetchXmlBuilder/packages.config
+++ b/FetchXmlBuilder/packages.config
@@ -23,6 +23,6 @@
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net472" />
-  <package id="xrmtb.XrmToolBox.Controls" version="2.2.4" targetFramework="net472" />
+  <package id="xrmtb.XrmToolBox.Controls" version="2.2.10" targetFramework="net472" />
   <package id="XrmToolBoxPackage" version="1.2020.11.42" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Added new option to output JSON data in format more similar to that produced by WebAPI responses.
Both old and new JSON formats now use Newtonsoft rather than manual string manipulation to avoid encoding errors
Fixes #451 