### PR TITLE
Replaced XMLViewer with Scintilla

### DIFF
--- a/FetchXmlBuilder/AppCode/FXBSettings.cs
+++ b/FetchXmlBuilder/AppCode/FXBSettings.cs
@@ -1,9 +1,12 @@
 ﻿using Cinteros.Xrm.FetchXmlBuilder.DockControls;
+using ScintillaNET;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.IO;
 using System.Linq;
+using System.Xml;
 using System.Xml.Serialization;
 using WeifenLuo.WinFormsUI.Docking;
 using xrmtb.XrmToolBox.Controls;
@@ -196,16 +199,19 @@ namespace Cinteros.Xrm.FetchXmlBuilder.AppCode
         [XmlIgnore()]
         public Color Comment { get; set; } = Color.Gray;
         [XmlIgnore()]
+        [Browsable(false)]
         public Color Tag { get; set; } = Color.Blue;
 
-        public void ApplyToControl(XMLViewer viewer)
+        public void ApplyToControl(Scintilla viewer)
         {
-            viewer.Settings.AttributeKey = AttributeKey;
-            viewer.Settings.AttributeValue = AttributeValue;
-            viewer.Settings.Comment = Comment;
-            viewer.Settings.Element = Element;
-            viewer.Settings.Tag = Tag;
-            viewer.Settings.Value = Value;
+            viewer.Styles[Style.Default].ForeColor = Value;
+            viewer.Styles[Style.Xml.Attribute].ForeColor = AttributeKey;
+            viewer.Styles[Style.Xml.DoubleString].ForeColor = AttributeValue;
+            viewer.Styles[Style.Xml.SingleString].ForeColor = AttributeValue;
+            viewer.Styles[Style.Xml.Comment].ForeColor = Comment;
+            viewer.Styles[Style.Xml.Entity].ForeColor = Value;
+            viewer.Styles[Style.Xml.Tag].ForeColor = Element;
+            viewer.Styles[Style.Xml.TagEnd].ForeColor = Element;
         }
     }
 

--- a/FetchXmlBuilder/DockControls/XmlContentControl.designer.cs
+++ b/FetchXmlBuilder/DockControls/XmlContentControl.designer.cs
@@ -30,14 +30,12 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(XmlContentControl));
-            xrmtb.XrmToolBox.Controls.XMLViewerSettings xmlViewerSettings1 = new xrmtb.XrmToolBox.Controls.XMLViewerSettings();
             this.btnSave = new System.Windows.Forms.Button();
             this.btnExecute = new System.Windows.Forms.Button();
             this.btnParseQE = new System.Windows.Forms.Button();
             this.btnOk = new System.Windows.Forms.Button();
             this.panCancel = new System.Windows.Forms.Panel();
             this.btnCancel = new System.Windows.Forms.Button();
-            this.txtXML = new xrmtb.XrmToolBox.Controls.XMLViewer();
             this.panActions = new System.Windows.Forms.Panel();
             this.gbActions = new System.Windows.Forms.GroupBox();
             this.panSQL4CDS = new System.Windows.Forms.Panel();
@@ -60,6 +58,7 @@
             this.tt = new System.Windows.Forms.ToolTip(this.components);
             this.panSQL4CDSInfo = new System.Windows.Forms.Panel();
             this.lblSQL4CDSInfo = new System.Windows.Forms.Label();
+            this.txtXML = new ScintillaNET.Scintilla();
             this.panCancel.SuspendLayout();
             this.panActions.SuspendLayout();
             this.gbActions.SuspendLayout();
@@ -141,30 +140,6 @@
             this.btnCancel.Text = "Close";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
-            // 
-            // txtXML
-            // 
-            this.txtXML.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.txtXML.CurrentParseError = null;
-            this.txtXML.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.txtXML.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtXML.FormatAsYouType = true;
-            this.txtXML.Location = new System.Drawing.Point(0, 0);
-            this.txtXML.Name = "txtXML";
-            xmlViewerSettings1.AttributeKey = System.Drawing.Color.Blue;
-            xmlViewerSettings1.AttributeValue = System.Drawing.Color.DarkRed;
-            xmlViewerSettings1.Comment = System.Drawing.Color.Gray;
-            xmlViewerSettings1.Element = System.Drawing.Color.DarkGreen;
-            xmlViewerSettings1.FontName = "Consolas";
-            xmlViewerSettings1.FontSize = 9F;
-            xmlViewerSettings1.QuoteCharacter = '\"';
-            xmlViewerSettings1.Tag = System.Drawing.Color.ForestGreen;
-            xmlViewerSettings1.Value = System.Drawing.Color.Black;
-            this.txtXML.Settings = xmlViewerSettings1;
-            this.txtXML.Size = new System.Drawing.Size(682, 229);
-            this.txtXML.TabIndex = 0;
-            this.txtXML.Text = "";
-            this.txtXML.TextChanged += new System.EventHandler(this.txtXML_TextChanged);
             // 
             // panActions
             // 
@@ -405,6 +380,15 @@
     "t it from the Tool Library and enable SQL 4 CDS in FetchXML Builder Options to g" +
     "et even more accurate results.";
             // 
+            // txtXML
+            // 
+            this.txtXML.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtXML.Location = new System.Drawing.Point(0, 0);
+            this.txtXML.Name = "txtXML";
+            this.txtXML.Size = new System.Drawing.Size(682, 229);
+            this.txtXML.TabIndex = 12;
+            this.txtXML.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtXML_KeyPress);
+            // 
             // XmlContentControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -424,9 +408,9 @@
             this.Name = "XmlContentControl";
             this.DockStateChanged += new System.EventHandler(this.XmlContentDisplayDialog_DockStateChanged);
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.XmlContentDisplayDialog_FormClosing);
+            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.XmlContentDisplayDialog_KeyDown);
             this.Load += new System.EventHandler(this.XmlContentDisplayDialog_Load);
             this.VisibleChanged += new System.EventHandler(this.XmlContentDisplayDialog_VisibleChanged);
-            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.XmlContentDisplayDialog_KeyDown);
             this.panCancel.ResumeLayout(false);
             this.panActions.ResumeLayout(false);
             this.gbActions.ResumeLayout(false);
@@ -450,7 +434,6 @@
         private System.Windows.Forms.Button btnOk;
         private System.Windows.Forms.Panel panCancel;
         private System.Windows.Forms.Button btnCancel;
-        internal xrmtb.XrmToolBox.Controls.XMLViewer txtXML;
         internal System.Windows.Forms.Button btnExecute;
         internal System.Windows.Forms.Button btnParseQE;
         private System.Windows.Forms.Button btnSave;
@@ -476,5 +459,6 @@
         private System.Windows.Forms.Button btnSQL4CDS;
         private System.Windows.Forms.Panel panSQL4CDSInfo;
         private System.Windows.Forms.Label lblSQL4CDSInfo;
+        internal ScintillaNET.Scintilla txtXML;
     }
 }

--- a/FetchXmlBuilder/FetchXmlBuilder.csproj
+++ b/FetchXmlBuilder/FetchXmlBuilder.csproj
@@ -344,6 +344,7 @@
       <DependentUpon>fetch.xsd</DependentUpon>
     </Compile>
     <Compile Include="AppCode\SQLQueryGenerator.cs" />
+    <Compile Include="ScintillaHelper.cs" />
     <Compile Include="WebAPIMetadataProvider.cs" />
     <Compile Include="XrmToolBoxToolIds.cs" />
   </ItemGroup>

--- a/FetchXmlBuilder/Forms/SelectMLDialog.Designer.cs
+++ b/FetchXmlBuilder/Forms/SelectMLDialog.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            xrmtb.XrmToolBox.Controls.XMLViewerSettings xmlViewerSettings1 = new xrmtb.XrmToolBox.Controls.XMLViewerSettings();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SelectMLDialog));
             this.panel1 = new System.Windows.Forms.Panel();
             this.cmbML = new System.Windows.Forms.ComboBox();
@@ -40,7 +39,7 @@
             this.panCancel = new System.Windows.Forms.Panel();
             this.button2 = new System.Windows.Forms.Button();
             this.panel3 = new System.Windows.Forms.Panel();
-            this.txtFetch = new xrmtb.XrmToolBox.Controls.XMLViewer();
+            this.txtFetch = new ScintillaNET.Scintilla();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
             this.panOk.SuspendLayout();
@@ -152,20 +151,11 @@
             // txtFetch
             // 
             this.txtFetch.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtFetch.Enabled = false;
             this.txtFetch.Location = new System.Drawing.Point(0, 0);
             this.txtFetch.Name = "txtFetch";
-            this.txtFetch.ReadOnly = true;
-            xmlViewerSettings1.AttributeKey = System.Drawing.Color.Red;
-            xmlViewerSettings1.AttributeValue = System.Drawing.Color.Blue;
-            xmlViewerSettings1.Comment = System.Drawing.Color.Empty;
-            xmlViewerSettings1.Element = System.Drawing.Color.DarkRed;
-            xmlViewerSettings1.QuoteCharacter = '\"';
-            xmlViewerSettings1.Tag = System.Drawing.Color.Blue;
-            xmlViewerSettings1.Value = System.Drawing.Color.Black;
-            this.txtFetch.Settings = xmlViewerSettings1;
             this.txtFetch.Size = new System.Drawing.Size(566, 338);
-            this.txtFetch.TabIndex = 3;
-            this.txtFetch.Text = "";
+            this.txtFetch.TabIndex = 0;
             // 
             // SelectMLDialog
             // 
@@ -201,8 +191,7 @@
         private System.Windows.Forms.Button btnOk;
         private System.Windows.Forms.Panel panCancel;
         private System.Windows.Forms.Button button2;
-        internal xrmtb.XrmToolBox.Controls.XMLViewer txtFetch;
         private System.Windows.Forms.Button btnRefresh;
-
+        private ScintillaNET.Scintilla txtFetch;
     }
 }

--- a/FetchXmlBuilder/Forms/SelectMLDialog.cs
+++ b/FetchXmlBuilder/Forms/SelectMLDialog.cs
@@ -15,7 +15,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         {
             InitializeComponent();
             Caller = caller;
-            caller.settings.XmlColors.ApplyToControl(txtFetch);
+            txtFetch.ConfigureForXml(caller.settings);
             PopulateForm();
         }
 
@@ -67,8 +67,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         {
             if (cmbML.SelectedItem is ViewItem)
             {
-                txtFetch.Text = ((ViewItem)cmbML.SelectedItem).GetFetch();
-                txtFetch.Process();
+                txtFetch.FormatXML(((ViewItem)cmbML.SelectedItem).GetFetch(), Caller.settings);
                 btnOk.Enabled = true;
             }
             else

--- a/FetchXmlBuilder/Forms/SelectViewDialog.Designer.cs
+++ b/FetchXmlBuilder/Forms/SelectViewDialog.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            xrmtb.XrmToolBox.Controls.XMLViewerSettings xmlViewerSettings1 = new xrmtb.XrmToolBox.Controls.XMLViewerSettings();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SelectViewDialog));
             this.panel1 = new System.Windows.Forms.Panel();
             this.cmbView = new System.Windows.Forms.ComboBox();
@@ -43,7 +42,7 @@
             this.panCancel = new System.Windows.Forms.Panel();
             this.button2 = new System.Windows.Forms.Button();
             this.panel3 = new System.Windows.Forms.Panel();
-            this.txtFetch = new xrmtb.XrmToolBox.Controls.XMLViewer();
+            this.txtFetch = new ScintillaNET.Scintilla();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
             this.panOk.SuspendLayout();
@@ -194,20 +193,11 @@
             // txtFetch
             // 
             this.txtFetch.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtFetch.Enabled = false;
             this.txtFetch.Location = new System.Drawing.Point(0, 0);
             this.txtFetch.Name = "txtFetch";
-            this.txtFetch.ReadOnly = true;
-            xmlViewerSettings1.AttributeKey = System.Drawing.Color.Red;
-            xmlViewerSettings1.AttributeValue = System.Drawing.Color.Blue;
-            xmlViewerSettings1.Comment = System.Drawing.Color.Empty;
-            xmlViewerSettings1.Element = System.Drawing.Color.DarkRed;
-            xmlViewerSettings1.QuoteCharacter = '\"';
-            xmlViewerSettings1.Tag = System.Drawing.Color.Blue;
-            xmlViewerSettings1.Value = System.Drawing.Color.Black;
-            this.txtFetch.Settings = xmlViewerSettings1;
             this.txtFetch.Size = new System.Drawing.Size(566, 313);
-            this.txtFetch.TabIndex = 3;
-            this.txtFetch.Text = "";
+            this.txtFetch.TabIndex = 0;
             // 
             // SelectViewDialog
             // 
@@ -246,8 +236,8 @@
         private System.Windows.Forms.Button btnOk;
         private System.Windows.Forms.Panel panCancel;
         private System.Windows.Forms.Button button2;
-        internal xrmtb.XrmToolBox.Controls.XMLViewer txtFetch;
         private System.Windows.Forms.Button btnRefresh;
         private System.Windows.Forms.Label lblNotCusomizable;
+        private ScintillaNET.Scintilla txtFetch;
     }
 }

--- a/FetchXmlBuilder/Forms/SelectViewDialog.cs
+++ b/FetchXmlBuilder/Forms/SelectViewDialog.cs
@@ -15,7 +15,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         {
             InitializeComponent();
             Caller = caller;
-            caller.settings.XmlColors.ApplyToControl(txtFetch);
+            txtFetch.ConfigureForXml(caller.settings);
             PopulateForm();
         }
 
@@ -119,8 +119,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         {
             if (cmbView.SelectedItem is ViewItem viewitem)
             {
-                txtFetch.Text = viewitem.GetFetch();
-                txtFetch.Process();
+                txtFetch.FormatXML(viewitem.GetFetch(), Caller.settings);
                 lblNotCusomizable.Visible = !viewitem.IsCustomizable;
                 btnOk.Enabled = true;
             }

--- a/FetchXmlBuilder/Forms/Settings.Designer.cs
+++ b/FetchXmlBuilder/Forms/Settings.Designer.cs
@@ -30,7 +30,6 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         /// </summary>
         private void InitializeComponent()
         {
-            xrmtb.XrmToolBox.Controls.XMLViewerSettings xmlViewerSettings1 = new xrmtb.XrmToolBox.Controls.XMLViewerSettings();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Settings));
             Cinteros.Xrm.FetchXmlBuilder.AppCode.XmlColors xmlColors1 = new Cinteros.Xrm.FetchXmlBuilder.AppCode.XmlColors();
             this.gbEntities = new System.Windows.Forms.GroupBox();
@@ -75,15 +74,15 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnOK = new System.Windows.Forms.Button();
             this.gbDefaultQuery = new System.Windows.Forms.GroupBox();
-            this.txtFetch = new xrmtb.XrmToolBox.Controls.XMLViewer();
             this.panel2 = new System.Windows.Forms.Panel();
             this.btnDefaultQuery = new System.Windows.Forms.Button();
             this.btnFormatQuery = new System.Windows.Forms.Button();
             this.gbXml = new System.Windows.Forms.GroupBox();
             this.btnResetXmlColors = new System.Windows.Forms.Button();
+            this.propXmlColors = new System.Windows.Forms.PropertyGrid();
             this.gbBehavior = new System.Windows.Forms.GroupBox();
             this.chkAddConditionToFilter = new System.Windows.Forms.CheckBox();
-            this.propXmlColors = new System.Windows.Forms.PropertyGrid();
+            this.txtFetch = new ScintillaNET.Scintilla();
             this.gbEntities.SuspendLayout();
             this.gbAttributes.SuspendLayout();
             this.gbResult.SuspendLayout();
@@ -609,29 +608,6 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             this.gbDefaultQuery.TabStop = false;
             this.gbDefaultQuery.Text = "Default New Query";
             // 
-            // txtFetch
-            // 
-            this.txtFetch.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtFetch.CurrentParseError = null;
-            this.txtFetch.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.txtFetch.FormatAsYouType = true;
-            this.txtFetch.Location = new System.Drawing.Point(3, 16);
-            this.txtFetch.Name = "txtFetch";
-            xmlViewerSettings1.AttributeKey = System.Drawing.Color.Red;
-            xmlViewerSettings1.AttributeValue = System.Drawing.Color.Blue;
-            xmlViewerSettings1.Comment = System.Drawing.Color.Empty;
-            xmlViewerSettings1.Element = System.Drawing.Color.DarkRed;
-            xmlViewerSettings1.FontName = "Consolas";
-            xmlViewerSettings1.FontSize = 9F;
-            xmlViewerSettings1.QuoteCharacter = '\"';
-            xmlViewerSettings1.Tag = System.Drawing.Color.Blue;
-            xmlViewerSettings1.Value = System.Drawing.Color.Black;
-            this.txtFetch.Settings = xmlViewerSettings1;
-            this.txtFetch.Size = new System.Drawing.Size(364, 90);
-            this.txtFetch.TabIndex = 4;
-            this.txtFetch.Text = "";
-            this.txtFetch.Leave += new System.EventHandler(this.txtFetch_Leave);
-            // 
             // panel2
             // 
             this.panel2.Controls.Add(this.btnDefaultQuery);
@@ -684,30 +660,6 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             this.btnResetXmlColors.UseVisualStyleBackColor = true;
             this.btnResetXmlColors.Click += new System.EventHandler(this.btnResetXmlColors_Click);
             // 
-            // gbBehavior
-            // 
-            this.gbBehavior.Controls.Add(this.chkAddConditionToFilter);
-            this.gbBehavior.Controls.Add(this.chkResAllPages);
-            this.gbBehavior.Controls.Add(this.chkUseSQL4CDS);
-            this.gbBehavior.Controls.Add(this.chkAppNoSavePrompt);
-            this.gbBehavior.Controls.Add(this.chkAppResultsNewWindow);
-            this.gbBehavior.Location = new System.Drawing.Point(12, 163);
-            this.gbBehavior.Name = "gbBehavior";
-            this.gbBehavior.Size = new System.Drawing.Size(222, 125);
-            this.gbBehavior.TabIndex = 2;
-            this.gbBehavior.TabStop = false;
-            this.gbBehavior.Text = "Behavior";
-            // 
-            // chkAddConditionToFilter
-            // 
-            this.chkAddConditionToFilter.AutoSize = true;
-            this.chkAddConditionToFilter.Location = new System.Drawing.Point(16, 80);
-            this.chkAddConditionToFilter.Name = "chkAddConditionToFilter";
-            this.chkAddConditionToFilter.Size = new System.Drawing.Size(193, 17);
-            this.chkAddConditionToFilter.TabIndex = 4;
-            this.chkAddConditionToFilter.Text = "Add Condition to Filter automatically";
-            this.chkAddConditionToFilter.UseVisualStyleBackColor = true;
-            // 
             // propXmlColors
             // 
             this.propXmlColors.CanShowVisualStyleGlyphs = false;
@@ -734,6 +686,38 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             this.propXmlColors.ToolbarVisible = false;
             this.propXmlColors.ViewBorderColor = System.Drawing.SystemColors.Window;
             this.propXmlColors.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.propXmlColors_PropertyValueChanged);
+            // 
+            // gbBehavior
+            // 
+            this.gbBehavior.Controls.Add(this.chkAddConditionToFilter);
+            this.gbBehavior.Controls.Add(this.chkResAllPages);
+            this.gbBehavior.Controls.Add(this.chkUseSQL4CDS);
+            this.gbBehavior.Controls.Add(this.chkAppNoSavePrompt);
+            this.gbBehavior.Controls.Add(this.chkAppResultsNewWindow);
+            this.gbBehavior.Location = new System.Drawing.Point(12, 163);
+            this.gbBehavior.Name = "gbBehavior";
+            this.gbBehavior.Size = new System.Drawing.Size(222, 125);
+            this.gbBehavior.TabIndex = 2;
+            this.gbBehavior.TabStop = false;
+            this.gbBehavior.Text = "Behavior";
+            // 
+            // chkAddConditionToFilter
+            // 
+            this.chkAddConditionToFilter.AutoSize = true;
+            this.chkAddConditionToFilter.Location = new System.Drawing.Point(16, 80);
+            this.chkAddConditionToFilter.Name = "chkAddConditionToFilter";
+            this.chkAddConditionToFilter.Size = new System.Drawing.Size(193, 17);
+            this.chkAddConditionToFilter.TabIndex = 4;
+            this.chkAddConditionToFilter.Text = "Add Condition to Filter automatically";
+            this.chkAddConditionToFilter.UseVisualStyleBackColor = true;
+            // 
+            // txtFetch
+            // 
+            this.txtFetch.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtFetch.Location = new System.Drawing.Point(3, 16);
+            this.txtFetch.Name = "txtFetch";
+            this.txtFetch.Size = new System.Drawing.Size(364, 90);
+            this.txtFetch.TabIndex = 6;
             // 
             // Settings
             // 
@@ -812,7 +796,6 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         private System.Windows.Forms.LinkLabel llShowWelcome;
         private System.Windows.Forms.CheckBox chkAppAllowUncustViews;
         private System.Windows.Forms.GroupBox gbDefaultQuery;
-        internal xrmtb.XrmToolBox.Controls.XMLViewer txtFetch;
         private System.Windows.Forms.Panel panel2;
         private System.Windows.Forms.Button btnFormatQuery;
         private System.Windows.Forms.Button btnDefaultQuery;
@@ -827,5 +810,6 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         private System.Windows.Forms.CheckBox chkAddConditionToFilter;
         private System.Windows.Forms.CheckBox chkShowButtonTexts;
         private System.Windows.Forms.RadioButton rbResSerializedJSONWebAPI;
+        private ScintillaNET.Scintilla txtFetch;
     }
 }

--- a/FetchXmlBuilder/Forms/Settings.cs
+++ b/FetchXmlBuilder/Forms/Settings.cs
@@ -41,9 +41,8 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
             }
             chkResAllPages.Checked = settings.Results.RetrieveAllPages;
             propXmlColors.SelectedObject = settings.XmlColors;
-            settings.XmlColors.ApplyToControl(txtFetch);
-            txtFetch.Text = settings.QueryOptions.NewQueryTemplate;
-            txtFetch.Process();
+            txtFetch.ConfigureForXml(settings);
+            txtFetch.FormatXML(settings.QueryOptions.NewQueryTemplate, settings);
             chkEntAll.Checked = settings.Entity.All;
             if (!settings.Entity.All)
             {
@@ -212,7 +211,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         {
             try
             {
-                txtFetch.Process();
+                txtFetch.FormatXML(txtFetch.Text, fxb.settings);
             }
             catch (Exception ex)
             {
@@ -224,8 +223,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         {
             if (string.IsNullOrWhiteSpace(txtFetch.Text))
             {
-                txtFetch.Text = QueryOptions.DefaultNewQuery;
-                txtFetch.Process();
+                txtFetch.FormatXML(QueryOptions.DefaultNewQuery, fxb.settings);
             }
         }
 
@@ -233,7 +231,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
         {
             try
             {
-                txtFetch.Process();
+                txtFetch.FormatXML(txtFetch.Text, fxb.settings);
             }
             catch (Exception ex)
             {
@@ -244,8 +242,7 @@ namespace Cinteros.Xrm.FetchXmlBuilder.Forms
 
         private void btnDefaultQuery_Click(object sender, EventArgs e)
         {
-            txtFetch.Text = QueryOptions.DefaultNewQuery;
-            txtFetch.Process();
+            txtFetch.FormatXML(QueryOptions.DefaultNewQuery, fxb.settings);
         }
 
         private void propXmlColors_PropertyValueChanged(object s, PropertyValueChangedEventArgs e)

--- a/FetchXmlBuilder/ScintillaHelper.cs
+++ b/FetchXmlBuilder/ScintillaHelper.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Cinteros.Xrm.FetchXmlBuilder.AppCode;
+using ScintillaNET;
+
+namespace Cinteros.Xrm.FetchXmlBuilder
+{
+    static class ScintillaHelper
+    {
+        public static void ConfigureForXml(this Scintilla scintilla, FXBSettings settings)
+        {
+            // Ref: https://gist.github.com/anonymous/63036aa8c1cefcfcb013
+
+            // Reset the styles
+            scintilla.StyleResetDefault();
+            scintilla.Styles[Style.Default].Font = "Consolas";
+            scintilla.Styles[Style.Default].Size = 10;
+            scintilla.StyleClearAll();
+
+            // Set the XML Lexer
+            scintilla.Lexer = Lexer.Xml;
+
+            // Show line numbers
+            scintilla.Margins[0].Width = 20;
+
+            // Enable folding
+            scintilla.SetProperty("fold", "1");
+            scintilla.SetProperty("fold.compact", "1");
+            scintilla.SetProperty("fold.html", "1");
+
+            // Use Margin 2 for fold markers
+            scintilla.Margins[2].Type = MarginType.Symbol;
+            scintilla.Margins[2].Mask = Marker.MaskFolders;
+            scintilla.Margins[2].Sensitive = true;
+            scintilla.Margins[2].Width = 20;
+
+            // Reset folder markers
+            for (int i = Marker.FolderEnd; i <= Marker.FolderOpen; i++)
+            {
+                scintilla.Markers[i].SetForeColor(SystemColors.ControlLightLight);
+                scintilla.Markers[i].SetBackColor(SystemColors.ControlDark);
+            }
+
+            // Style the folder markers
+            scintilla.Markers[Marker.Folder].Symbol = MarkerSymbol.BoxPlus;
+            scintilla.Markers[Marker.Folder].SetBackColor(SystemColors.ControlText);
+            scintilla.Markers[Marker.FolderOpen].Symbol = MarkerSymbol.BoxMinus;
+            scintilla.Markers[Marker.FolderEnd].Symbol = MarkerSymbol.BoxPlusConnected;
+            scintilla.Markers[Marker.FolderEnd].SetBackColor(SystemColors.ControlText);
+            scintilla.Markers[Marker.FolderMidTail].Symbol = MarkerSymbol.TCorner;
+            scintilla.Markers[Marker.FolderOpenMid].Symbol = MarkerSymbol.BoxMinusConnected;
+            scintilla.Markers[Marker.FolderSub].Symbol = MarkerSymbol.VLine;
+            scintilla.Markers[Marker.FolderTail].Symbol = MarkerSymbol.LCorner;
+
+            // Enable automatic folding
+            scintilla.AutomaticFold = AutomaticFold.Show | AutomaticFold.Click | AutomaticFold.Change;
+
+            // Set the Styles
+            scintilla.StyleResetDefault();
+
+            // I like fixed font for XML
+            scintilla.Styles[Style.Default].Font = "Courier New";
+            scintilla.Styles[Style.Default].Size = 10;
+            scintilla.StyleClearAll();
+
+            settings.XmlColors.ApplyToControl(scintilla);
+        }
+
+        public static void ConfigureForCSharp(this Scintilla scintilla)
+        {
+            // Ref: https://github.com/jacobslusser/ScintillaNET/wiki/Automatic-Syntax-Highlighting#complete-recipe
+
+            // Configuring the default style with properties
+            // we have common to every lexer style saves time.
+            scintilla.StyleResetDefault();
+            scintilla.Styles[Style.Default].Font = "Consolas";
+            scintilla.Styles[Style.Default].Size = 10;
+            scintilla.StyleClearAll();
+
+            // Configure the CPP (C#) lexer styles
+            scintilla.Styles[Style.Cpp.Default].ForeColor = Color.Silver;
+            scintilla.Styles[Style.Cpp.Comment].ForeColor = Color.FromArgb(0, 128, 0); // Green
+            scintilla.Styles[Style.Cpp.CommentLine].ForeColor = Color.FromArgb(0, 128, 0); // Green
+            scintilla.Styles[Style.Cpp.CommentLineDoc].ForeColor = Color.FromArgb(128, 128, 128); // Gray
+            scintilla.Styles[Style.Cpp.Number].ForeColor = Color.Olive;
+            scintilla.Styles[Style.Cpp.Word].ForeColor = Color.Blue;
+            scintilla.Styles[Style.Cpp.Word2].ForeColor = Color.Blue;
+            scintilla.Styles[Style.Cpp.String].ForeColor = Color.FromArgb(163, 21, 21); // Red
+            scintilla.Styles[Style.Cpp.Character].ForeColor = Color.FromArgb(163, 21, 21); // Red
+            scintilla.Styles[Style.Cpp.Verbatim].ForeColor = Color.FromArgb(163, 21, 21); // Red
+            scintilla.Styles[Style.Cpp.StringEol].BackColor = Color.Pink;
+            scintilla.Styles[Style.Cpp.Operator].ForeColor = Color.Purple;
+            scintilla.Styles[Style.Cpp.Preprocessor].ForeColor = Color.Maroon;
+            scintilla.Lexer = Lexer.Cpp;
+
+            // Set the keywords
+            scintilla.SetKeywords(0, "abstract as base break case catch checked continue default delegate do else event explicit extern false finally fixed for foreach goto if implicit in interface internal is lock namespace new null object operator out override params private protected public readonly ref return sealed sizeof stackalloc switch this throw true try typeof unchecked unsafe using virtual while");
+            scintilla.SetKeywords(1, "bool byte char class const decimal double enum float int long sbyte short static string struct uint ulong ushort void");
+        }
+
+        public static void ConfigureForSQL(this Scintilla scintilla)
+        {
+            // Ref: https://gist.githubusercontent.com/jcouture100/f5d58df816445a1d74df10883618eab4/raw/1e3a6d7c20a15ccbd3c970d5c6a0a864fe80054e/MsSqlRecipe.cs
+
+            // Reset the styles
+            scintilla.StyleResetDefault();
+            scintilla.Styles[Style.Default].Font = "Courier New";
+            scintilla.Styles[Style.Default].Size = 10;
+            scintilla.StyleClearAll();
+
+            // Set the SQL Lexer
+            scintilla.Lexer = Lexer.Sql;
+
+            // Show line numbers
+            scintilla.Margins[0].Width = 20;
+
+            // Set the Styles
+            scintilla.Styles[Style.LineNumber].ForeColor = Color.FromArgb(255, 128, 128, 128);  //Dark Gray
+            scintilla.Styles[Style.LineNumber].BackColor = Color.FromArgb(255, 228, 228, 228);  //Light Gray
+            scintilla.Styles[Style.Sql.Comment].ForeColor = Color.Green;
+            scintilla.Styles[Style.Sql.CommentLine].ForeColor = Color.Green;
+            scintilla.Styles[Style.Sql.CommentLineDoc].ForeColor = Color.Green;
+            scintilla.Styles[Style.Sql.Number].ForeColor = Color.Maroon;
+            scintilla.Styles[Style.Sql.Word].ForeColor = Color.Blue;
+            scintilla.Styles[Style.Sql.Word2].ForeColor = Color.Fuchsia;
+            scintilla.Styles[Style.Sql.User1].ForeColor = Color.Gray;
+            scintilla.Styles[Style.Sql.User2].ForeColor = Color.FromArgb(255, 00, 128, 192);    //Medium Blue-Green
+            scintilla.Styles[Style.Sql.String].ForeColor = Color.Red;
+            scintilla.Styles[Style.Sql.Character].ForeColor = Color.Red;
+            scintilla.Styles[Style.Sql.Operator].ForeColor = Color.Black;
+
+            // Set keyword lists
+            // Word = 0
+            scintilla.SetKeywords(0, @"add alter as authorization backup begin bigint binary bit break browse bulk by cascade case catch check checkpoint close clustered column commit compute constraint containstable continue create current cursor cursor database date datetime datetime2 datetimeoffset dbcc deallocate decimal declare default delete deny desc disk distinct distributed double drop dump else end errlvl escape except exec execute exit external fetch file fillfactor float for foreign freetext freetexttable from full function goto grant group having hierarchyid holdlock identity identity_insert identitycol if image index insert int intersect into key kill lineno load merge money national nchar nocheck nocount nolock nonclustered ntext numeric nvarchar of off offsets on open opendatasource openquery openrowset openxml option order over percent plan precision primary print proc procedure public raiserror read readtext real reconfigure references replication restore restrict return revert revoke rollback rowcount rowguidcol rule save schema securityaudit select set setuser shutdown smalldatetime smallint smallmoney sql_variant statistics table table tablesample text textsize then time timestamp tinyint to top tran transaction trigger truncate try union unique uniqueidentifier update updatetext use user values varbinary varchar varying view waitfor when where while with writetext xml go ");
+            // Word2 = 1
+            scintilla.SetKeywords(1, @"ascii cast char charindex ceiling coalesce collate contains convert current_date current_time current_timestamp current_user floor isnull max min nullif object_id session_user substring system_user tsequal ");
+            // User1 = 4
+            scintilla.SetKeywords(4, @"all and any between cross exists in inner is join left like not null or outer pivot right some unpivot ( ) * ");
+            // User2 = 5
+            scintilla.SetKeywords(5, @"sys objects sysobjects ");
+        }
+
+        public static void ConfigureForJavaScript(this Scintilla scintilla)
+        {
+            // Ref: https://github.com/jacobslusser/ScintillaNET/wiki/Automatic-Syntax-Highlighting#complete-recipe
+
+            // Configuring the default style with properties
+            // we have common to every lexer style saves time.
+            scintilla.StyleResetDefault();
+            scintilla.Styles[Style.Default].Font = "Consolas";
+            scintilla.Styles[Style.Default].Size = 10;
+            scintilla.StyleClearAll();
+
+            // Configure the CPP (C#) lexer styles
+            scintilla.Styles[Style.Cpp.Default].ForeColor = Color.Silver;
+            scintilla.Styles[Style.Cpp.Comment].ForeColor = Color.FromArgb(0, 128, 0); // Green
+            scintilla.Styles[Style.Cpp.CommentLine].ForeColor = Color.FromArgb(0, 128, 0); // Green
+            scintilla.Styles[Style.Cpp.CommentLineDoc].ForeColor = Color.FromArgb(128, 128, 128); // Gray
+            scintilla.Styles[Style.Cpp.Number].ForeColor = Color.Olive;
+            scintilla.Styles[Style.Cpp.Word].ForeColor = Color.Blue;
+            scintilla.Styles[Style.Cpp.Word2].ForeColor = Color.Blue;
+            scintilla.Styles[Style.Cpp.String].ForeColor = Color.FromArgb(163, 21, 21); // Red
+            scintilla.Styles[Style.Cpp.Character].ForeColor = Color.FromArgb(163, 21, 21); // Red
+            scintilla.Styles[Style.Cpp.Verbatim].ForeColor = Color.FromArgb(163, 21, 21); // Red
+            scintilla.Styles[Style.Cpp.StringEol].BackColor = Color.Pink;
+            scintilla.Styles[Style.Cpp.Operator].ForeColor = Color.Purple;
+            scintilla.Styles[Style.Cpp.Preprocessor].ForeColor = Color.Maroon;
+            scintilla.Lexer = Lexer.Cpp;
+
+            // Set the keywords
+            scintilla.SetKeywords(0, "abstract as base break case catch checked continue default delegate do else event explicit extern false finally fixed for foreach goto if implicit in interface internal is lock namespace new null object operator out override params private protected public readonly ref return sealed sizeof stackalloc switch this throw true try typeof unchecked unsafe using virtual while");
+            scintilla.SetKeywords(1, "bool byte char class const decimal double enum float int long sbyte short static string struct uint ulong ushort void");
+        }
+
+        public static void ConfigureForJSON(this Scintilla scintilla)
+        {
+            // Reset the styles
+            scintilla.StyleResetDefault();
+            scintilla.Styles[Style.Default].Font = "Consolas";
+            scintilla.Styles[Style.Default].Size = 10;
+            scintilla.StyleClearAll();
+
+            // Set the XML Lexer
+            scintilla.Lexer = Lexer.Json;
+
+            // Show line numbers
+            scintilla.Margins[0].Width = 20;
+
+            // Enable folding
+            scintilla.SetProperty("fold", "1");
+            scintilla.SetProperty("fold.compact", "1");
+
+            // Use Margin 2 for fold markers
+            scintilla.Margins[2].Type = MarginType.Symbol;
+            scintilla.Margins[2].Mask = Marker.MaskFolders;
+            scintilla.Margins[2].Sensitive = true;
+            scintilla.Margins[2].Width = 20;
+
+            // Reset folder markers
+            for (int i = Marker.FolderEnd; i <= Marker.FolderOpen; i++)
+            {
+                scintilla.Markers[i].SetForeColor(SystemColors.ControlLightLight);
+                scintilla.Markers[i].SetBackColor(SystemColors.ControlDark);
+            }
+
+            // Style the folder markers
+            scintilla.Markers[Marker.Folder].Symbol = MarkerSymbol.BoxPlus;
+            scintilla.Markers[Marker.Folder].SetBackColor(SystemColors.ControlText);
+            scintilla.Markers[Marker.FolderOpen].Symbol = MarkerSymbol.BoxMinus;
+            scintilla.Markers[Marker.FolderEnd].Symbol = MarkerSymbol.BoxPlusConnected;
+            scintilla.Markers[Marker.FolderEnd].SetBackColor(SystemColors.ControlText);
+            scintilla.Markers[Marker.FolderMidTail].Symbol = MarkerSymbol.TCorner;
+            scintilla.Markers[Marker.FolderOpenMid].Symbol = MarkerSymbol.BoxMinusConnected;
+            scintilla.Markers[Marker.FolderSub].Symbol = MarkerSymbol.VLine;
+            scintilla.Markers[Marker.FolderTail].Symbol = MarkerSymbol.LCorner;
+
+            // Enable automatic folding
+            scintilla.AutomaticFold = AutomaticFold.Show | AutomaticFold.Click | AutomaticFold.Change;
+
+            // Set the Styles
+            scintilla.StyleResetDefault();
+
+            // I like fixed font for XML
+            scintilla.Styles[Style.Default].Font = "Courier New";
+            scintilla.Styles[Style.Default].Size = 10;
+            scintilla.StyleClearAll();
+        }
+
+        public static void FormatXML(this Scintilla scintilla, string text, FXBSettings settings)
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml(text);
+            using (var writer = new StringWriter())
+            using (var xmlWriter = new XmlFragmentWriter(writer))
+            {
+                xmlWriter.QuoteChar = settings.QueryOptions.UseSingleQuotation ? '\'' : '"';
+                xmlWriter.Formatting = Formatting.Indented;
+
+                doc.Save(xmlWriter);
+                scintilla.Text = writer.ToString();
+            }
+        }
+    }
+}

--- a/XmlEditorUtils/FindTextHandler.cs
+++ b/XmlEditorUtils/FindTextHandler.cs
@@ -1,10 +1,11 @@
 ﻿using System.Windows.Forms;
+using ScintillaNET;
 
 namespace Cinteros.Xrm.XmlEditorUtils
 {
     public class FindTextHandler
     {
-        public static string HandleFindKeyPress(KeyEventArgs e, RichTextBox textBox, string findtext)
+        public static string HandleFindKeyPress(KeyEventArgs e, Scintilla textBox, string findtext)
         {
             var result = findtext;
             var findHandled = false;
@@ -30,7 +31,7 @@ namespace Cinteros.Xrm.XmlEditorUtils
             return result;
         }
 
-        private static int FindTheText(RichTextBox textBox, string text, int start)
+        private static int FindTheText(Scintilla textBox, string text, int start)
         {
             // Initialize the return value to false by default.
             int returnValue = -1;
@@ -43,11 +44,14 @@ namespace Cinteros.Xrm.XmlEditorUtils
                     textBox.Focus();
                 }
                 // Obtain the location of the search string in richTextBox1.
-                int indexToText = textBox.Find(text, start, RichTextBoxFinds.None);
+                textBox.TargetStart = start;
+                textBox.TargetEnd = textBox.TextLength;
+                int indexToText = textBox.SearchInTarget(text);
                 // Determine whether the text was found in richTextBox1.
                 if (indexToText >= 0)
                 {
                     returnValue = indexToText;
+                    textBox.SetSel(textBox.TargetStart, textBox.TargetEnd);
                 }
             }
             if (returnValue == -1)

--- a/XmlEditorUtils/XmlEditorUtils.csproj
+++ b/XmlEditorUtils/XmlEditorUtils.csproj
@@ -66,6 +66,9 @@
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework" />
+    <Reference Include="ScintillaNET, Version=3.6.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Activities" />
     <Reference Include="System.Activities.Presentation" />

--- a/XmlEditorUtils/packages.config
+++ b/XmlEditorUtils/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="jacobslusser.ScintillaNET" version="3.6.3" targetFramework="net472" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.32" targetFramework="net472" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.32" targetFramework="net472" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.32" targetFramework="net472" />


### PR DESCRIPTION
Using Scintilla instead of the existing XMLViewer component:

* improves syntax highlighting for XML documents
* adds syntax highlighting for other languages (SQL, C#, Javascript, JSON)
* adds line number and code folding

I'd also like to use this as the foundation for other Intellisense-type features.

![image](https://user-images.githubusercontent.com/31017244/125808850-de2d3456-775d-4c58-b94d-d735926983fc.png)

This should respect the colour settings that were already defined for XML documents, but I've currently got it just using some default colours for other languages. It doesn't differentiate between the &lt;&gt; characters and the element name though, so there will be a slight difference in colouring compared to the existing version.