### PR TITLE
Intellisense fix when loading attributes for a new link-entity

### DIFF
--- a/FetchXmlBuilder/DockControls/XmlContentControl.cs
+++ b/FetchXmlBuilder/DockControls/XmlContentControl.cs
@@ -611,10 +611,6 @@ namespace Cinteros.Xrm.FetchXmlBuilder.DockControls
 
                     e.Suggestions.AddRange(attributes.OrderBy(attr => attr.LogicalName).Select(attr => new AttributeMetadataSuggestion(attr, fxb.settings.UseFriendlyNames)));
                 }
-                else if (fxb.NeedToLoadEntity(entityNode.GetAttribute("name")))
-                {
-                    fxb.LoadEntityDetails(entityNode.GetAttribute("name"), null);
-                }
             }
 
             // Autocomplete alias names for <condition> and <order> elements


### PR DESCRIPTION
Starting with a query like:

```xml
<fetch>
  <entity name="account">
  </entity>
</fetch>
```

Start typing a link-entity to join to contacts:

```xml
<fetch>
  <entity name="account">
    <link-entity name="contact" from=""
  </entity>
</fetch>
```

Press <kbd>Ctrl</kbd>+<kbd>Space</kbd> to open the Intellisense autocomplete for the `from` attribute. If the metadata hasn't already been loaded for the contact entity, the existing code will call `LoadEntityDetails` which eventually refreshes the FetchXML from the Query Builder and removes the partial `<link-entity>`.

This change removes that call so the metadata is loaded in the background by the `TryGetAttributes` method. The autocomplete list will not show immediately, but once the metadata has finished loading in the background it will show on the next keypress.