### PR TITLE
Fix C# code generation for linkentities with OR root filter

### DIFF
--- a/FetchXmlBuilder/Converters/CSharpCodeGenerator.cs
+++ b/FetchXmlBuilder/Converters/CSharpCodeGenerator.cs
@@ -236,7 +236,7 @@ namespace Rappen.XTB.FetchXmlBuilder.Converters
             var code = new StringBuilder();
             filter.FilterHint = $"{ownerName}.{(ownerType == OwnersType.Root ? "Criteria" : ownerType == OwnersType.Link ? "LinkCriteria" : "Filters")}";
             var rootfilters = filter.FilterHint.EndsWith("Criteria") || filter.FilterHint.EndsWith("Criteria.Filters");
-            if (ownerType == OwnersType.Sub)
+            if (ownerType == OwnersType.Sub || (ownerType == OwnersType.Link && (filter.FilterOperator == LogicalOperator.Or || !filter.Conditions.Any())))
             {
                 filter.FilterHint = GetVarName($"{ownerName}.{(filter.FilterOperator == LogicalOperator.Or ? "Or" : "And")}".Replace(".Criteria", "").Replace(".LinkCriteria", ""), several);
 
@@ -591,7 +591,7 @@ namespace Rappen.XTB.FetchXmlBuilder.Converters
                     break;
 
                 default:
-                    if (ownerType == OwnersType.Sub)
+                    if (ownerType == OwnersType.Sub || (ownerType == OwnersType.Link && (filter.FilterOperator == LogicalOperator.Or || !filter.Conditions.Any())))
                     {
                         code.Append($"{Indent(indentslevel)}new FilterExpression({(filter.FilterOperator == LogicalOperator.Or ? "LogicalOperator.Or" : "")}){CRLF}{Indent(indentslevel++)}{{{CRLF}");
                     }


### PR DESCRIPTION
Hi,

we have noticed that when a link entitiy has its root filter set to the OR type, despite the fetchxml being correct, the generated QueryExpress C# code is not. It does not create a new filterexpression and the default one is of type AND.

This PR fixes the issue by appling the same logic used for OwnersType.Sub also for ownerType == OwnersType.Link (only when filter is of type OR and there is at least one condition).

The following screenshot shows the generated code before and after the fix:

![image](https://github.com/rappen/FetchXMLBuilder/assets/830773/237a7b09-5724-4cfa-9082-2a5c7723b0c6)

![image](https://github.com/rappen/FetchXMLBuilder/assets/830773/8e76c1b9-818c-4e3a-ad55-4256da1b7199)
