### PR TITLE
Updated fetchxml conversion to c sharp to avoid collision

### DIFF
--- a/FetchXmlBuilder/Converters/CSharpCodeGenerator.cs
+++ b/FetchXmlBuilder/Converters/CSharpCodeGenerator.cs
@@ -322,7 +322,7 @@ namespace Rappen.XTB.FetchXmlBuilder.Converters
             foreach (var link in linkEntities)
             {
                 var linkcode = string.Empty;
-                var linkname = GetVarName(string.IsNullOrEmpty(link.EntityAlias) ? LineStart + "_" + link.LinkToEntityName : link.EntityAlias);
+                 var linkname = GetVarName(string.IsNullOrEmpty(link.EntityAlias) || link.LinkToEntityName == link.EntityAlias ? LineStart + "_" + link.LinkToEntityName : link.EntityAlias);
                 if (settings.IncludeComments)
                 {
                     linkcode += $"//{CRLF}// Add link-entity {linkname}{CRLF}";


### PR DESCRIPTION
Hello! This is my first contribution to any public repository, so I apologize in advance for any mistakes.

The Situation:

When using this tool, some users may paste the entity logical name to easily access aliased values from the resulting collection (without appending "1" if left blank). While this method is straightforward, it poses a problem. The variable holding the link entity object will inevitably conflict because its name is the same as the early bound class (when present).

The Solution:

Without excessive engineering, a simple compare to prefix the logical name

thanks in advance