### PR TITLE
Openai

### DIFF
--- a/FXBTests/app.config
+++ b/FXBTests/app.config
@@ -90,6 +90,14 @@
         <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.5" newVersion="9.0.0.5" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" /></startup></configuration>

--- a/FetchXmlBuilder/FetchXmlBuilder.csproj
+++ b/FetchXmlBuilder/FetchXmlBuilder.csproj
@@ -71,6 +71,9 @@
     <Reference Include="Microsoft.Extensions.AI.Abstractions, Version=9.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.AI.Abstractions.9.5.0\lib\net462\Microsoft.Extensions.AI.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.AI.OpenAI, Version=9.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.AI.OpenAI.9.5.0-preview.1.25265.7\lib\net462\Microsoft.Extensions.AI.OpenAI.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.Caching.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Caching.Abstractions.8.0.0\lib\net462\Microsoft.Extensions.Caching.Abstractions.dll</HintPath>
     </Reference>
@@ -132,6 +135,9 @@
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="OpenAI, Version=2.2.0.0, Culture=neutral, PublicKeyToken=b4187f3e65366280, processorArchitecture=MSIL">
+      <HintPath>..\packages\OpenAI.2.2.0-beta.4\lib\netstandard2.0\OpenAI.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="ScintillaNET, Version=3.6.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll</HintPath>
@@ -141,6 +147,9 @@
     <Reference Include="System.Activities.Presentation" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ClientModel, Version=1.2.1.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.2.1\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -164,6 +173,9 @@
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory.Data, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.8.0.1\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/FetchXmlBuilder/app.config
+++ b/FetchXmlBuilder/app.config
@@ -94,6 +94,18 @@
         <assemblyIdentity name="System.Net.ServerSentEvents" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.5" newVersion="9.0.0.5" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>

--- a/FetchXmlBuilder/packages.config
+++ b/FetchXmlBuilder/packages.config
@@ -13,6 +13,7 @@
   <package id="Microsoft.CrmSdk.XrmTooling.WpfControls" version="9.1.1.65" targetFramework="net48" />
   <package id="Microsoft.Extensions.AI" version="9.5.0" targetFramework="net48" />
   <package id="Microsoft.Extensions.AI.Abstractions" version="9.5.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.AI.OpenAI" version="9.5.0-preview.1.25265.7" targetFramework="net48" />
   <package id="Microsoft.Extensions.Caching.Abstractions" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.2" targetFramework="net48" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="8.0.3" targetFramework="net48" />
@@ -27,11 +28,14 @@
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net472" />
   <package id="MscrmTools.Xrm.Connection" version="1.2023.6.56" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
+  <package id="OpenAI" version="2.2.0-beta.4" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.ClientModel" version="1.2.1" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="8.0.1" targetFramework="net48" />
   <package id="System.IO" version="4.3.0" targetFramework="net472" />
   <package id="System.IO.Pipelines" version="9.0.2" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
+  <package id="System.Memory.Data" version="8.0.1" targetFramework="net48" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net472" />
   <package id="System.Net.ServerSentEvents" version="9.0.2" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />


### PR DESCRIPTION
Added references to OpenAI and Microsoft.Extensions.AI.OpenAI, to allow for the usage of the IChatClient abstraction while using the official OpenAI SDK in Rappen.XTB.Helpers.