### PR TITLE
Added messages about tool calls and their results to the chathistory,…

### DIFF
--- a/FetchXmlBuilder/AppCode/SimpleMeta.cs
+++ b/FetchXmlBuilder/AppCode/SimpleMeta.cs
@@ -46,10 +46,8 @@ namespace Rappen.XTB.FXB.AppCode
         {
             if (em == null ||
                 string.IsNullOrEmpty(em.LogicalName) ||
-                !em.LogicalName.Contains("_") ||
                 em.LogicalName.StartsWith("msdyn_") ||
-                em.LogicalName.StartsWith("msfp_") ||
-                em.ToDisplayName().Equals(em.LogicalName, StringComparison.InvariantCultureIgnoreCase))
+                em.LogicalName.StartsWith("msfp_"))
             {
                 return null;
             }
@@ -60,10 +58,8 @@ namespace Rappen.XTB.FXB.AppCode
         {
             if (am == null ||
                 string.IsNullOrEmpty(am.LogicalName) ||
-                !am.LogicalName.Contains("_") ||
                 am.LogicalName.StartsWith("msdyn_") ||
-                am.LogicalName.StartsWith("msfp_") ||
-                am.ToDisplayName().Equals(am.LogicalName, StringComparison.InvariantCultureIgnoreCase))
+                am.LogicalName.StartsWith("msfp_"))
             {
                 return null;
             }


### PR DESCRIPTION
… to avoid unnecessary calling of tools multiple times. Relaxed the restrictions to which metadata that is returned - it now also returns metadata for non-custom entities/attributes, but at the same time we have made the system prompts stricter, so that tools are not called for 'standard' entities, if not absolutely necessary.