### PR TITLE
Add intelligent metadata matching for Dataverse entities and attributes

### DIFF
--- a/FetchXmlBuilder/FetchXmlBuilder.csproj
+++ b/FetchXmlBuilder/FetchXmlBuilder.csproj
@@ -58,6 +58,9 @@
     <Reference Include="CSharpToJsonSchema, Version=3.0.0.0, Culture=neutral, PublicKeyToken=20925763ef4043f0, processorArchitecture=MSIL">
       <HintPath>..\packages\CSharpToJsonSchema.3.10.1\lib\net462\CSharpToJsonSchema.dll</HintPath>
     </Reference>
+    <Reference Include="F23.StringSimilarity, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\F23.StringSimilarity.6.0.0\lib\netstandard2.0\F23.StringSimilarity.dll</HintPath>
+    </Reference>
     <Reference Include="McTools.Xrm.Connection, Version=1.2025.7.63, Culture=neutral, PublicKeyToken=96037217801d9658, processorArchitecture=MSIL">
       <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2025.7.63\lib\net48\McTools.Xrm.Connection.dll</HintPath>
     </Reference>
@@ -888,6 +891,7 @@
   move /Y "OpenAI.*" Plugins\Rappen.XTB.FXB
   move /Y "Microsoft.Extensions.AI.OpenAI.*" Plugins\Rappen.XTB.FXB
   move /Y "Azure.*.*" Plugins\Rappen.XTB.FXB
+  move /Y "F23.StringSimilarity*.*" Plugins\Rappen.XTB.FXB
 )
 
 

--- a/FetchXmlBuilder/packages.config
+++ b/FetchXmlBuilder/packages.config
@@ -6,6 +6,7 @@
   <package id="CSharpToJsonSchema" version="3.10.1" targetFramework="net48" />
   <package id="DockPanelSuite" version="3.0.6" targetFramework="net472" />
   <package id="DockPanelSuite.ThemeVS2015" version="3.0.6" targetFramework="net472" />
+  <package id="F23.StringSimilarity" version="6.0.0" targetFramework="net48" />
   <package id="jacobslusser.ScintillaNET" version="3.6.3" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.7" targetFramework="net48" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.59" targetFramework="net48" />


### PR DESCRIPTION
- Introduced DataverseMetadataMatcher for improved entity/attribute search
- Added F23.StringSimilarity package for fuzzy string matching
- Implemented synonym support for common business terms
- Added quick match logic before falling back to AI sampling
- Commented out redundant AI sampling messages after query execution

This improves the speed and accuracy of finding Dataverse metadata by using local string matching algorithms before resorting to AI calls.

🤖 Generated with [Claude Code](https://claude.ai/code)