### PR TITLE
Fix matchfirstrowusingcrossapply link-entity columns not showing in grid view

### DIFF
--- a/FetchXmlBuilder/Builder/TreeNodeExtensions.cs
+++ b/FetchXmlBuilder/Builder/TreeNodeExtensions.cs
@@ -107,13 +107,16 @@ namespace Rappen.XTB.FetchXmlBuilder.Builder
         internal static bool IsAttributeValidForView(this TreeNode node)
         {
             var entity = node.Parent;
-            return node.Name == "attribute" && (entity?.Name == "entity" || (entity?.Name == "link-entity" && !string.IsNullOrWhiteSpace(entity.Value("alias"))));
+            return node.Name == "attribute" && (entity?.Name == "entity" ||
+                (entity?.Name == "link-entity" && (!string.IsNullOrWhiteSpace(entity.Value("alias")) || entity.Value("link-type") == "matchfirstrowusingcrossapply")));
         }
 
         internal static string GetAttributeLayoutName(this TreeNode node)
         {
             var entity = node.LocalEntityNode();
-            var entityalias = entity.Name == "link-entity" ? entity.Value("alias") : string.Empty;
+            var entityalias = entity.Name == "link-entity" && entity.Value("link-type") != "matchfirstrowusingcrossapply"
+                ? entity.Value("alias")
+                : string.Empty;
             var attribute = node.Value("name");
             var alias = node.Value("alias");
             if (!string.IsNullOrWhiteSpace(alias))

--- a/FetchXmlBuilder/Builder/Validations.cs
+++ b/FetchXmlBuilder/Builder/Validations.cs
@@ -112,13 +112,14 @@ namespace Rappen.XTB.FetchXmlBuilder.Builder
             {
                 return new ControlValidationResult(ControlValidationLevel.Warning, "Link-Entity must include Name, To, From");
             }
+            var type = node.Value("link-type");
             if (fxb.settings.Layout.Enabled &&
                 string.IsNullOrWhiteSpace(alias) &&
+                type != "matchfirstrowusingcrossapply" &&
                 node.Nodes.OfType<TreeNode>().Any(n => n.Name == "attribute"))
             {
                 return new ControlValidationResult(ControlValidationLevel.Warning, "Using Layout: Alias is needed to show these attributes");
             }
-            var type = node.Value("link-type");
             if (node.Parent is TreeNode parent && parent.Name == "filter")
             {
                 if (!type.Equals("any") && !type.Equals("not any") && !type.Equals("all") && !type.Equals("not all"))


### PR DESCRIPTION
## Why

When a `link-entity` uses `link-type="matchfirstrowusingcrossapply"`, the attributes from that link-entity were not appearing in the grid (Result View). The JSON view worked correctly.

This is caused by a [documented inconsistency in Dataverse](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/fetchxml/join-tables#use-matchfirstrowusingcrossapply-link-type): unlike all other link types, `matchfirstrowusingcrossapply` returns column names using `SchemaName` (PascalCase) **without** any alias prefix. FetchXMLBuilder was unaware of this special behaviour.

Fixes #1181.

## What changed

Three small fixes, all gated on detecting `link-type = "matchfirstrowusingcrossapply"`:

**`Builder/TreeNodeExtensions.cs`**
- **`IsAttributeValidForView`** — previously required the link-entity to have an alias before its attributes were considered valid for the grid layout. Now also allows attributes when the link-type is `matchfirstrowusingcrossapply` (alias not needed).
- **`GetAttributeLayoutName`** — previously always prefixed linked attributes with `alias.`. Now skips the prefix for `matchfirstrowusingcrossapply`, so the layout name matches the un-prefixed column names returned by Dataverse.

**`Builder/Validations.cs`**
- **`ValidateLinkEntity`** — the "Using Layout: Alias is needed to show these attributes" warning is now suppressed for `matchfirstrowusingcrossapply` link-entities, since no alias is needed or useful for this type.