### PR TITLE
Fix #1178: Remove unused layout variable left over from Excel export refactor

### DIFF
--- a/FetchXmlBuilder/DockControls/ResultGrid.cs
+++ b/FetchXmlBuilder/DockControls/ResultGrid.cs
@@ -329,7 +329,6 @@ namespace Rappen.XTB.FetchXmlBuilder.DockControls
             mnuExcel.Enabled = false;
             Cursor = Cursors.WaitCursor;
             var fetch = queryinfo.Query is FetchExpression fetchexpr ? fetchexpr.Query : queryinfo.Query.ToString();
-            var layout = form.dockControlBuilder?.LayoutXML?.ToXMLString();
             crmGridView1.ExportToExcel(form.settings.Results.ExcelAddLinks, fetch, () =>
             {
                 mnuExcel.Enabled = true;


### PR DESCRIPTION
## Summary

Closes #1178

### Root cause

In release `v1.2025.12.1` (Dec 14, 2025), the Excel export used `ExcelHelper.ExportClipboardToExcel` which failed with:

> `System.InvalidOperationException: Cannot set a value on node type 'Element'`

This was caused by XML node manipulation in the old helper when processing large result sets (~33,000 rows).

### Fix (already in master since Dec 18, 2025)

Commit `e8cfecc` replaced the old `ExcelHelper` with the built-in `XRMDataGridView.ExportToExcel` method which uses direct COM automation (bulk 2D array write) instead of clipboard paste. The new implementation correctly handles large datasets.

### This PR

Removes the `layout` variable left as dead code in `OpenInExcel()` after the refactor — it was computed but never passed to the new `ExportToExcel` call (which doesn't take a layout parameter).

```csharp
// Removed dead code:
var layout = form.dockControlBuilder?.LayoutXML?.ToXMLString();
```